### PR TITLE
[Bugfix] Fix CTest integration in IDEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,4 +28,6 @@ add_subdirectory(cmake/FetchTaskflow)
 
 # Processes the CMakeLists.txt for each target.
 add_subdirectory(src)
+
+include(CTest)
 add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@
 cmake_minimum_required(VERSION 3.26)
 project(Oasis)
 
+include(CTest)
 include(FetchContent)
 
 # Fetches dependencies and integrates them into the project.
@@ -29,5 +30,6 @@ add_subdirectory(cmake/FetchTaskflow)
 # Processes the CMakeLists.txt for each target.
 add_subdirectory(src)
 
-include(CTest)
-add_subdirectory(tests)
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,5 @@ target_link_libraries(OasisTests PRIVATE Oasis::Oasis Catch2::Catch2WithMain)
 
 # Automatically registers the tests with CTest.
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
-include(CTest)
 include(Catch)
 catch_discover_tests(OasisTests)


### PR DESCRIPTION
In #17, building the unit test executable was moved to a subdirectory of the project root. This inadvertently messed up CTest, especially its integration with IDEs like Visual Studio. Specifically, the `include(CTest)` statement must be present in the top-level `CMakeLists.txt`, so that it can invoke `enable_testing()`. This pull request fixes this issue.