### PR TITLE
[Bugfix] replace abs with std::abs

### DIFF
--- a/src/Exponent.cpp
+++ b/src/Exponent.cpp
@@ -60,7 +60,7 @@ auto Exponent<Expression>::Simplify() const -> std::unique_ptr<Expression>
     if (auto ImgCase = Exponent<Multiply<Real, Expression>, Real>::Specialize(simplifiedExponent); ImgCase != nullptr) {
         if (ImgCase->GetMostSigOp().GetMostSigOp().GetValue() < 0 && ImgCase->GetLeastSigOp().GetValue() == 0.5) {
             return std::make_unique<Multiply<Expression>>(
-                Multiply<Expression> { Real { pow(abs(ImgCase->GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
+                Multiply<Expression> { Real { pow(std::abs(ImgCase->GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
                     Exponent<Expression> { ImgCase->GetMostSigOp().GetLeastSigOp(), Real { 0.5 } } },
                 Imaginary {});
         }


### PR DESCRIPTION
Fixed build warning. Closes #23.