### PR TITLE
[Workflow] Expedite building Oasis in the build and test workflow

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -77,11 +77,19 @@ jobs:
                 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
             # Builds Oasis with the given configuration.
-          - name: Build
+          - name: Build Oasis
             run: >
                 cmake
                 --build ${{ steps.strings.outputs.build-output-dir }}
                 --config ${{ matrix.build_type }}
+                --target Oasis
+
+          - name: Build Test
+            run: >
+                cmake
+                --build ${{ steps.strings.outputs.build-output-dir }}
+                --config ${{ matrix.build_type }}
+                --target OasisTests
 
             # Runs the tests registered to CTest by CMake.
           - name: Test


### PR DESCRIPTION
The current CI process takes an excessive amount of time to run due to it currently building all targets. This PR aims to improve CI runtimes by explicitly specifying targets to build. Namely, it builds the Oasis target first so that compile-time errors in the library can be caught early.