### PR TITLE
[Workflow] Treat all warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ add_subdirectory(cmake/FetchTaskflow)
 if(MSVC)
     add_compile_options("$<$<CONFIG:DEBUG>:/W3>" "$<$<CONFIG:DEBUG>:/WX>")
 else()
-    add_compile_options("$<$<CONFIG:DEBUG>:-Wall -Wextra -Wpedantic -Werror>")
+    add_compile_options("$<$<CONFIG:DEBUG>:-Wall>" "$<$<CONFIG:DEBUG>:-Wextra>" "$<$<CONFIG:DEBUG>:-Wpedantic>" "$<$<CONFIG:DEBUG>:-Werror>")
 endif()
 
 # Processes the CMakeLists.txt for each target.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,14 +27,6 @@ FetchContent_MakeAvailable(Catch2 fmt)
 add_subdirectory(cmake/FetchEigen)
 add_subdirectory(cmake/FetchTaskflow)
 
-if(MSVC)
-    add_compile_options("$<$<CONFIG:DEBUG>:/W3>" "$<$<CONFIG:DEBUG>:/WX>")
-else()
-    add_compile_options(
-        "$<$<CONFIG:DEBUG>:-Wall>" "$<$<CONFIG:DEBUG>:-Wextra>"
-        "$<$<CONFIG:DEBUG>:-Wpedantic>" "$<$<CONFIG:DEBUG>:-Werror>")
-endif()
-
 # Processes the CMakeLists.txt for each target.
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # OASIS: Open Algebra Software for Inferring Solutions
 #
 # CMakeLists.txt - Top-level
-# #############################################################################
+# ##############################################################################
 
 cmake_minimum_required(VERSION 3.26)
 project(Oasis)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ FetchContent_MakeAvailable(Catch2 fmt)
 add_subdirectory(cmake/FetchEigen)
 add_subdirectory(cmake/FetchTaskflow)
 
+if(MSVC)
+    add_compile_options("$<$<CONFIG:DEBUG>:/W3>" "$<$<CONFIG:DEBUG>:/WX>")
+else()
+    add_compile_options("$<$<CONFIG:DEBUG>:-Wall -Wextra -Wpedantic -Werror>")
+endif()
+
 # Processes the CMakeLists.txt for each target.
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # OASIS: Open Algebra Software for Inferring Solutions
 #
 # CMakeLists.txt - Top-level
-# ##############################################################################
+# #############################################################################
 
 cmake_minimum_required(VERSION 3.26)
 project(Oasis)

--- a/include/Oasis/BinaryExpression.hpp
+++ b/include/Oasis/BinaryExpression.hpp
@@ -365,14 +365,15 @@ public:
     {
         DerivedSpecialized copy;
 
+        // This is not actually parallelized.
         if (this->mostSigOp) {
-            subflow.emplace([this, &copy](tf::Subflow& sbf) {
+            subflow.emplace([this, &copy](tf::Subflow&) {
                 copy.SetMostSigOp(*this->mostSigOp);
             });
         }
 
         if (this->leastSigOp) {
-            subflow.emplace([this, &copy](tf::Subflow& sbf) {
+            subflow.emplace([this, &copy](tf::Subflow&) {
                 copy.SetLeastSigOp(*this->leastSigOp);
             });
         }
@@ -487,14 +488,15 @@ public:
     {
         std::unique_ptr<DerivedGeneralized> copy = std::make_unique<DerivedGeneralized>();
 
+        // This is not actually parallelized.
         if (mostSigOp) {
-            subflow.emplace([this, &copy](tf::Subflow& sbf) {
+            subflow.emplace([this, &copy](tf::Subflow&) {
                 copy->SetMostSigOp(*mostSigOp);
             });
         }
 
         if (leastSigOp) {
-            subflow.emplace([&](tf::Subflow& sbf) {
+            subflow.emplace([&](tf::Subflow&) {
                 copy->SetLeastSigOp(*leastSigOp);
             });
         }
@@ -587,7 +589,7 @@ auto BuildFromVector(const std::vector<std::unique_ptr<Expression>>& ops) -> std
     std::vector<std::unique_ptr<Expression>> reducedOps;
     reducedOps.reserve((ops.size() / 2) + 1);
 
-    for (int i = 0; i < ops.size(); i += 2) {
+    for (unsigned int i = 0; i < ops.size(); i += 2) {
         if (i + 1 >= ops.size()) {
             reducedOps.push_back(ops[i]->Copy());
             break;

--- a/include/Oasis/LeafExpression.hpp
+++ b/include/Oasis/LeafExpression.hpp
@@ -34,7 +34,7 @@ public:
         return this->GetType() == other.GetType();
     }
 
-    auto StructurallyEquivalent(const Expression& other, tf::Subflow& subflow) const -> bool final
+    auto StructurallyEquivalent(const Expression& other, tf::Subflow&) const -> bool final
     {
         return this->GetType() == other.GetType();
     }

--- a/src/Add.cpp
+++ b/src/Add.cpp
@@ -139,7 +139,7 @@ auto Add<Expression>::Simplify(tf::Subflow& subflow) const -> std::unique_ptr<Ex
     Add simplifiedAdd;
 
     // While this task isn't actually parallelized, it exists as a prerequisite for check possible cases in parallel
-    tf::Task simplifyTask = subflow.emplace([&simplifiedAdd, &simplifiedAugend, &simplifiedAddend](tf::Subflow& sbf) {
+    tf::Task simplifyTask = subflow.emplace([&simplifiedAdd, &simplifiedAugend, &simplifiedAddend](tf::Subflow&) {
         if (simplifiedAugend) {
             simplifiedAdd.SetMostSigOp(*simplifiedAugend);
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,7 @@ set(Oasis_HEADERS
 add_library(Oasis ${Oasis_SOURCES} ${Oasis_HEADERS})
 
 if(MSVC)
-    target_compile_options(Oasis PRIVATE /W3> /WX>)
+    target_compile_options(Oasis PRIVATE /W3 /WX)
 else()
     target_compile_options(Oasis PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,12 @@ set(Oasis_HEADERS
 # Adds a library target called "Oasis" to be built from source files.
 add_library(Oasis ${Oasis_SOURCES} ${Oasis_HEADERS})
 
+if(MSVC)
+    target_compile_options(Oasis PRIVATE "$<$<CONFIG:DEBUG>:/W3>" "$<$<CONFIG:DEBUG>:/WX>")
+else()
+    target_compile_options(Oasis PRIVATE "$<$<CONFIG:DEBUG>:-Wall>" "$<$<CONFIG:DEBUG>:-Wextra>" "$<$<CONFIG:DEBUG>:-Wpedantic>" "$<$<CONFIG:DEBUG>:-Werror>")
+endif()
+
 target_compile_features(Oasis PUBLIC cxx_std_20)
 target_include_directories(Oasis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 target_link_libraries(Oasis PUBLIC fmt::fmt Eigen3::Eigen Taskflow)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,13 +38,9 @@ set(Oasis_HEADERS
 add_library(Oasis ${Oasis_SOURCES} ${Oasis_HEADERS})
 
 if(MSVC)
-    target_compile_options(Oasis PRIVATE "$<$<CONFIG:DEBUG>:/W3>"
-                                         "$<$<CONFIG:DEBUG>:/WX>")
+    target_compile_options(Oasis PRIVATE /W3> /WX>)
 else()
-    target_compile_options(
-        Oasis
-        PRIVATE "$<$<CONFIG:DEBUG>:-Wall>" "$<$<CONFIG:DEBUG>:-Wextra>"
-                "$<$<CONFIG:DEBUG>:-Wpedantic>" "$<$<CONFIG:DEBUG>:-Werror>")
+    target_compile_options(Oasis PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()
 
 target_compile_features(Oasis PUBLIC cxx_std_20)

--- a/src/Divide.cpp
+++ b/src/Divide.cpp
@@ -56,7 +56,7 @@ auto Divide<Expression>::Simplify(tf::Subflow& subflow) const -> std::unique_ptr
     Divide simplifiedDivide;
 
     // While this task isn't actually parallelized, it exists as a prerequisite for check possible cases in parallel
-    tf::Task simplifyTask = subflow.emplace([&simplifiedDivide, &simplifiedDividend, &simplifiedDivisor](tf::Subflow& sbf) {
+    tf::Task simplifyTask = subflow.emplace([&simplifiedDivide, &simplifiedDividend, &simplifiedDivisor](tf::Subflow&) {
         if (simplifiedDividend) {
             simplifiedDivide.SetMostSigOp(*simplifiedDividend);
         }

--- a/src/Exponent.cpp
+++ b/src/Exponent.cpp
@@ -22,8 +22,6 @@ auto Exponent<Expression>::Simplify() const -> std::unique_ptr<Expression>
     Exponent simplifiedExponent { *simplifiedBase, *simplifiedPower };
 
     if (auto zeroCase = Exponent<Expression, Real>::Specialize(simplifiedExponent); zeroCase != nullptr) {
-        // Variable is unused; is this intentional?
-        // const Expression& base = zeroCase->GetMostSigOp();
         const Real& power = zeroCase->GetLeastSigOp();
 
         if (power.GetValue() == 0.0) {

--- a/src/Exponent.cpp
+++ b/src/Exponent.cpp
@@ -60,7 +60,7 @@ auto Exponent<Expression>::Simplify() const -> std::unique_ptr<Expression>
     if (auto ImgCase = Exponent<Multiply<Real, Expression>, Real>::Specialize(simplifiedExponent); ImgCase != nullptr) {
         if (ImgCase->GetMostSigOp().GetMostSigOp().GetValue() < 0 && ImgCase->GetLeastSigOp().GetValue() == 0.5) {
             return std::make_unique<Multiply<Expression>>(
-                Multiply<Expression> { Real { pow(abs(ImgCase->GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
+                Multiply<Expression> { Real { pow(std::abs(ImgCase->GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
                     Exponent<Expression> { ImgCase->GetMostSigOp().GetLeastSigOp(), Real { 0.5 } } },
                 Imaginary {});
         }

--- a/src/Exponent.cpp
+++ b/src/Exponent.cpp
@@ -22,7 +22,8 @@ auto Exponent<Expression>::Simplify() const -> std::unique_ptr<Expression>
     Exponent simplifiedExponent { *simplifiedBase, *simplifiedPower };
 
     if (auto zeroCase = Exponent<Expression, Real>::Specialize(simplifiedExponent); zeroCase != nullptr) {
-        const Expression& base = zeroCase->GetMostSigOp();
+        // Variable is unused; is this intentional?
+        // const Expression& base = zeroCase->GetMostSigOp();
         const Real& power = zeroCase->GetLeastSigOp();
 
         if (power.GetValue() == 0.0) {
@@ -100,7 +101,7 @@ auto Exponent<Expression>::Simplify(tf::Subflow& subflow) const -> std::unique_p
 
     Exponent simplifiedExponent;
 
-    tf::Task simplifyTask = subflow.emplace([&simplifiedExponent, &simplifiedBase, &simplifiedPower](tf::Subflow& sbf) {
+    tf::Task simplifyTask = subflow.emplace([&simplifiedExponent, &simplifiedBase, &simplifiedPower](tf::Subflow&) {
         if (simplifiedPower) {
             simplifiedExponent.SetMostSigOp(*simplifiedBase);
         }

--- a/src/Exponent.cpp
+++ b/src/Exponent.cpp
@@ -60,7 +60,7 @@ auto Exponent<Expression>::Simplify() const -> std::unique_ptr<Expression>
     if (auto ImgCase = Exponent<Multiply<Real, Expression>, Real>::Specialize(simplifiedExponent); ImgCase != nullptr) {
         if (ImgCase->GetMostSigOp().GetMostSigOp().GetValue() < 0 && ImgCase->GetLeastSigOp().GetValue() == 0.5) {
             return std::make_unique<Multiply<Expression>>(
-                Multiply<Expression> { Real { pow(std::abs(ImgCase->GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
+                Multiply<Expression> { Real { pow(abs(ImgCase->GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
                     Exponent<Expression> { ImgCase->GetMostSigOp().GetLeastSigOp(), Real { 0.5 } } },
                 Imaginary {});
         }

--- a/src/Imaginary.cpp
+++ b/src/Imaginary.cpp
@@ -22,7 +22,7 @@ auto Imaginary::Specialize(const Expression& other) -> std::unique_ptr<Imaginary
     return other.Is<Imaginary>() ? std::make_unique<Imaginary>(dynamic_cast<const Imaginary&>(other)) : nullptr;
 }
 
-auto Imaginary::Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Imaginary>
+auto Imaginary::Specialize(const Expression& other, tf::Subflow&) -> std::unique_ptr<Imaginary>
 {
     return other.Is<Imaginary>() ? std::make_unique<Imaginary>(dynamic_cast<const Imaginary&>(other)) : nullptr;
 }

--- a/src/Multiply.cpp
+++ b/src/Multiply.cpp
@@ -188,7 +188,7 @@ auto Multiply<Expression>::Simplify(tf::Subflow& subflow) const -> std::unique_p
     Multiply simplifiedMultiply;
 
     // While this task isn't actually parallelized, it exists as a prerequisite for check possible cases in parallel
-    tf::Task simplifyTask = subflow.emplace([&simplifiedMultiply, &simplifiedMultiplicand, &simplifiedMultiplier](tf::Subflow& sbf) {
+    tf::Task simplifyTask = subflow.emplace([&simplifiedMultiply, &simplifiedMultiplicand, &simplifiedMultiplier](tf::Subflow&) {
         if (simplifiedMultiplicand) {
             simplifiedMultiply.SetMostSigOp(*simplifiedMultiplicand);
         }

--- a/src/Real.cpp
+++ b/src/Real.cpp
@@ -33,7 +33,7 @@ auto Real::Specialize(const Expression& other) -> std::unique_ptr<Real>
     return other.Is<Real>() ? std::make_unique<Real>(dynamic_cast<const Real&>(other)) : nullptr;
 }
 
-auto Real::Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Real>
+auto Real::Specialize(const Expression& other, tf::Subflow&) -> std::unique_ptr<Real>
 {
     return other.Is<Real>() ? std::make_unique<Real>(dynamic_cast<const Real&>(other)) : nullptr;
 }

--- a/src/Subtract.cpp
+++ b/src/Subtract.cpp
@@ -118,7 +118,7 @@ auto Subtract<Expression>::Simplify(tf::Subflow& subflow) const -> std::unique_p
     Subtract simplifiedSubtract;
 
     // While this task isn't actually parallelized, it exists as a prerequisite for check possible cases in parallel
-    tf::Task simplifyTask = subflow.emplace([&simplifiedSubtract, &simplifiedMinuend, &simplifiedSubtrahend](tf::Subflow& sbf) {
+    tf::Task simplifyTask = subflow.emplace([&simplifiedSubtract, &simplifiedMinuend, &simplifiedSubtrahend](tf::Subflow&) {
         if (simplifiedMinuend) {
             simplifiedSubtract.SetMostSigOp(*simplifiedMinuend);
         }

--- a/src/Variable.cpp
+++ b/src/Variable.cpp
@@ -30,7 +30,7 @@ auto Variable::Specialize(const Expression& other) -> std::unique_ptr<Variable>
     return other.Is<Variable>() ? std::make_unique<Variable>(dynamic_cast<const Variable&>(other)) : nullptr;
 }
 
-auto Variable::Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Variable>
+auto Variable::Specialize(const Expression& other, tf::Subflow&) -> std::unique_ptr<Variable>
 {
     return other.Is<Variable>() ? std::make_unique<Variable>(dynamic_cast<const Variable&>(other)) : nullptr;
 }

--- a/tests/BinaryExpressionTests.cpp
+++ b/tests/BinaryExpressionTests.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Flatten Function", "[TreeManip]")
 
     REQUIRE(flattened.size() == expected.size());
 
-    for (int i = 0; i < flattened.size(); i++) {
+    for (unsigned int i = 0; i < flattened.size(); i++) {
         REQUIRE(flattened[i]->Equals(*expected[i]));
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ set(Oasis_TESTS
 add_executable(OasisTests ${Oasis_TESTS})
 
 if(MSVC)
-    target_compile_options(OasisTests PRIVATE /W3> /WX>)
+    target_compile_options(OasisTests PRIVATE /W3 /WX)
 else()
     target_compile_options(OasisTests PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,13 +14,9 @@ set(Oasis_TESTS
 add_executable(OasisTests ${Oasis_TESTS})
 
 if(MSVC)
-    target_compile_options(OasisTests PRIVATE "$<$<CONFIG:DEBUG>:/W3>"
-                                              "$<$<CONFIG:DEBUG>:/WX>")
+    target_compile_options(OasisTests PRIVATE /W3> /WX>)
 else()
-    target_compile_options(
-        OasisTests
-        PRIVATE "$<$<CONFIG:DEBUG>:-Wall>" "$<$<CONFIG:DEBUG>:-Wextra>"
-                "$<$<CONFIG:DEBUG>:-Wpedantic>" "$<$<CONFIG:DEBUG>:-Werror>")
+    target_compile_options(OasisTests PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()
 
 add_library(Oasis::Oasis ALIAS Oasis)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,12 @@ set(Oasis_TESTS
 # Adds an executable target called "OasisTests" to be built from sources files.
 add_executable(OasisTests ${Oasis_TESTS})
 
+if(MSVC)
+    target_compile_options(OasisTests PRIVATE "$<$<CONFIG:DEBUG>:/W3>" "$<$<CONFIG:DEBUG>:/WX>")
+else()
+    target_compile_options(OasisTests PRIVATE "$<$<CONFIG:DEBUG>:-Wall>" "$<$<CONFIG:DEBUG>:-Wextra>" "$<$<CONFIG:DEBUG>:-Wpedantic>" "$<$<CONFIG:DEBUG>:-Werror>")
+endif()
+
 add_library(Oasis::Oasis ALIAS Oasis)
 target_link_libraries(OasisTests PRIVATE Oasis::Oasis Catch2::Catch2WithMain)
 


### PR DESCRIPTION
This pull request updates our build and test workflow to compile with as many practical warning flags as possible. For MSVC, this includes `/W3` and `/WX`. For all other compilers, this includes `-Wall`, `-Wextra`, `-Wpedantic`, and `-Werror`.

Files have also been modified to fix any new warnings emitted. Three classes of warnings have been patched:
* **Unused parameters:** in many instances, `tf::Subflow` was not being used, causing recursive calls to not be parallelized. This occurs elsewhere in the code, and has thus not been fixed. Rather, the warnings are suppressed by excluding the parameter name.
* **Different signedness:** trivial change from `int` to `unsigned int` (should really be `size_type`).
* **Unused variable:** in `Exponent.cpp`, there is an unused variable that may or may not be intentional.