### PR TITLE
[Feature] Made Equals work for Associative and Commutative Expressions.

### DIFF
--- a/include/Oasis/BinaryExpression.hpp
+++ b/include/Oasis/BinaryExpression.hpp
@@ -23,7 +23,7 @@ public:
 
     BinaryExpressionBase(const Expression& mostSigOp, const Expression& leastSigOp);
 
-    [[nodiscard]] auto Equals(const Expression& other) const -> bool final;
+    [[nodiscard]] auto Equals(const Expression& other) const -> bool override;
 
     [[nodiscard]] auto StructurallyEquivalent(const Expression& other) const -> bool override;
     auto StructurallyEquivalent(const Expression& other, tf::Subflow& subflow) const -> bool override;
@@ -397,7 +397,7 @@ public:
             return false;
         }
 
-        auto otherGeneralized = other.Generalize();
+        const auto otherGeneralized = other.Generalize();
         const auto& otherBinary = static_cast<const DerivedGeneralized&>(*otherGeneralized);
 
         auto thisFlattened = std::vector<std::unique_ptr<Expression>> {};

--- a/include/Oasis/Expression.hpp
+++ b/include/Oasis/Expression.hpp
@@ -84,6 +84,12 @@ public:
 
     /**
      * Compares this expression to another expression for equality.
+     *
+     * Two expressions are equal if they are structurally equivalent and have the same value.
+     * While this method considers the associativity and commutativity of expressions, it does not
+     * simplify the expressions before comparing them. For example, `Add<Real>(Real(1), Real(2))`
+     * and `Add<Real>(Real(2), Real(1))` are not equal, despite being structurally equivalent.
+     *
      * @param other The other expression.
      * @return Whether the two expressions are equal.
      */

--- a/tests/BinaryExpressionTests.cpp
+++ b/tests/BinaryExpressionTests.cpp
@@ -164,3 +164,56 @@ TEST_CASE("BuildFromVector Function", "[TreeManip]")
         REQUIRE(result->StructurallyEquivalent(expected));
     }
 }
+
+TEST_CASE("Equals follows associativity and commutativity")
+{
+    Oasis::Real real1 { 1.0 };
+    Oasis::Real real2 { 2.0 };
+    Oasis::Real real3 { 3.0 };
+
+    Oasis::Add add1 {
+        Oasis::Add {
+            real1,
+            real2 },
+        real3
+    };
+
+    // (1 + 2) + 3 == 1 + (2 + 3)
+    SECTION("Associativity")
+    {
+        Oasis::Add add2 {
+            real1,
+            Oasis::Add {
+                real2,
+                real3 }
+        };
+
+        REQUIRE(add1.Equals(add2));
+    }
+
+    // (1 + 2) + 3 == 3 + (1 + 2)
+    SECTION("Commutativity")
+    {
+        Oasis::Add add2 {
+            real3,
+            Oasis::Add {
+                real1,
+                real2 }
+        };
+
+        REQUIRE(add1.Equals(add2));
+    }
+
+    // (1 + 2) + 3 == (3 + 2) + 1
+    SECTION("Associativity and Commutativity")
+    {
+        Oasis::Add add2 {
+            Oasis::Add {
+                real3,
+                real2 },
+            real1
+        };
+
+        REQUIRE(add1.Equals(add2));
+    }
+}


### PR DESCRIPTION
The previous implementation of `Equals` would consider the following expression, $(1+2)+3$, not equal to $(2+3)+1$. This PR makes so that `Equals` does consider the two expressions equal without simplifying.