### PR TITLE
[Feature] Improve BinaryExpression Functions

### DIFF
--- a/include/Oasis/BinaryExpression.hpp
+++ b/include/Oasis/BinaryExpression.hpp
@@ -486,7 +486,7 @@ auto BuildFromVector(const std::vector<std::unique_ptr<Expression>>& ops) -> std
         }                                                                                                                \
                                                                                                                          \
         if (otherBinaryExpression.HasLeastSigOp()) {                                                                     \
-            specialized->SetLeastSigOp(SecondOp::Specialize(otherBinaryExpression.GetLeastSigOp()));                      \
+            specialized->SetLeastSigOp(SecondOp::Specialize(otherBinaryExpression.GetLeastSigOp()));                     \
             rightOperandSpecialized = specialized->HasLeastSigOp();                                                      \
         }                                                                                                                \
                                                                                                                          \
@@ -509,7 +509,7 @@ auto BuildFromVector(const std::vector<std::unique_ptr<Expression>>& ops) -> std
         }                                                                                                                \
                                                                                                                          \
         if (otherWithSwappedOps.HasLeastSigOp()) {                                                                       \
-            specialized->SetLeastSigOp(SecondOp::Specialize(otherWithSwappedOps.GetLeastSigOp()));                        \
+            specialized->SetLeastSigOp(SecondOp::Specialize(otherWithSwappedOps.GetLeastSigOp()));                       \
             rightOperandSpecialized = specialized->HasLeastSigOp();                                                      \
         }                                                                                                                \
                                                                                                                          \


### PR DESCRIPTION
This PR aims to add a number of improvements to BinaryExpression, namely:
- Parallelized `Copy()`
- Made `Specialize` more readable (and possibly more performant)
- Added overloads for `SetMostSigOp()` and `SetLeastSigOp()`. Specifically, it add overloads that accepts rvalues of `std::unique_ptr` to `Expression`s. This makes it so that calls to `Copy()` explicitly happen at the call site, and the resulting `unique_ptr` is moved into the `BinaryExpression` avoiding redundant copies.
- Made `SwapOperands` `const`
- Optimized `BuildFromVector`. Previously, `BuildFromVector` was implemented recursively where each recursive call maintained its own copy of the set of original expressions. This new implementation is iterative, and only maintains one copy of set the original expressions. 