### PR TITLE
[Bugfix[ Compile tests on Windows with /bigobj

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(OasisTests ${Oasis_TESTS})
 
 if(MSVC)
     target_compile_options(OasisTests PRIVATE /W3 /WX)
+    target_compile_options(OasisTests PRIVATE /bigobj)
 else()
     target_compile_options(OasisTests PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()


### PR DESCRIPTION
This pull request changes the `CMakeLists.txt` for the unit tests to use `/bigobj`. As found on multiple Windows systems, the `ExponentTests.cpp` generates fatal error [C1128](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/fatal-error-c1128).

Our chosen fix is to use the `/bigobj` compiler flag for all unit test files.