### PR TITLE
Downgrade CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # CMakeLists.txt - Top-level
 # ##############################################################################
 
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.18)
 project(Oasis)
 
 include(CTest)


### PR DESCRIPTION
This PR reduces the minimum CMake Required from 3.26 to 3.18 (The minimum imposed by Taskflow).