### PR TITLE
[Workflow] Enabled `/bigobj` flag for Windows builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(Oasis ${Oasis_SOURCES} ${Oasis_HEADERS})
 
 if(MSVC)
     target_compile_options(Oasis PRIVATE /W3 /WX)
+    target_compile_options(Oasis PRIVATE /bigobj)
 else()
     target_compile_options(Oasis PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()


### PR DESCRIPTION
See title. Some builds on Windows may fail due to exceeding the default section limits