### PR TITLE
[Workflow] Fix Code Coverage Reports for PRs opened from forks

### DIFF
--- a/.github/workflows/code-coverage-comment.yml
+++ b/.github/workflows/code-coverage-comment.yml
@@ -1,0 +1,81 @@
+# ##############################################################################
+# OASIS: Open Algebra Software for Inferring Solutions
+#
+# code-coverage-comment.yml
+# ##############################################################################
+
+name: Code Coverage Comment
+
+on:
+    workflow_run:
+        workflows: [ "Code Coverage" ]
+        types:
+          - completed
+
+permissions:
+    contents: read
+    issues: write
+    pull-requests: write
+
+jobs:
+    write-comment:
+        runs-on: ubuntu-latest
+        if: |
+            github.event.workflow_run.event == 'pull_request' &&
+            github.event.workflow_run.conclusion == 'success'
+
+        steps:
+            # Downloads the artifacts uploaded by the pull request workflow run.
+          - name: Download artifacts
+            uses: actions/github-script@v6
+            with:
+                script: |
+                    let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        run_id: context.payload.workflow_run.id,
+                    });
+
+                    let matchArtifact1 = artifacts.data.artifacts.filter((artifact) => {
+                        return artifact.name == "pr-number"
+                    })[0];
+                    let download1 = await github.rest.actions.downloadArtifact({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        artifact_id: matchArtifact1.id,
+                        archive_format: 'zip',
+                    });
+
+                    let matchArtifact2 = artifacts.data.artifacts.filter((artifact) => {
+                        return artifact.name == "build-test-cover"
+                    })[0];
+                    let download2 = await github.rest.actions.downloadArtifact({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        artifact_id: matchArtifact2.id,
+                        archive_format: 'zip',
+                    });
+
+                    let fs = require('fs');
+                    fs.writeFileSync('${{github.workspace}}/pr-number.zip', Buffer.from(download1.data));
+                    fs.writeFileSync('${{github.workspace}}/build-test-cover.zip', Buffer.from(download2.data));
+
+            # Unzips the artifacts.
+          - name: Unzip artifacts
+            run: unzip \*.zip
+
+            # Writes a comment on the pull request.
+          - name: Comment on PR
+            uses: actions/github-script@v6
+            with:
+                script: |
+                    let fs = require('fs');
+                    let issue_number = Number(fs.readFileSync('./issue_number'));
+                    let coverage_file = fs.readFileSync('./coverage/reports/index.txt');
+                    
+                    await github.rest.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issue_number,
+                        body: '```\n' + coverage_file + '\n```'
+                    });

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -10,9 +10,6 @@ on:
     pull_request:
         branches: [ "master" ]
 
-permissions:
-  pull-requests: write
-
 jobs:
     collect-coverage:
         runs-on: ubuntu-latest
@@ -29,6 +26,13 @@ jobs:
             run: |
                 echo "build-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
                 echo "coverage-dir=${{ github.workspace }}/coverage" >> "$GITHUB_OUTPUT"
+                echo "pr-dir=${{ github.workspace }}/pr" >> "$GITHUB_OUTPUT"
+
+            # Saves the PR number to use in writing a comment on the PR.
+          - name: Save PR number
+            run: |
+                mkdir -p ${{ steps.strings.outputs.pr-dir }}
+                echo "${{ github.event.number }}" > ${{ steps.strings.outputs.pr-dir }}/issue_number
 
             # Installs LLVM 17 on the runner.
           - name: Install LLVM 17
@@ -77,19 +81,20 @@ jobs:
             shell: bash
             run: |
                 llvm-profdata-17 merge -sparse oasis.profraw -o oasis.profdata
-                llvm-cov-17 report -instr-profile oasis.profdata ${{ steps.strings.outputs.build-dir }}/tests/OasisTests -sources ${{ github.workspace }}/src ${{ github.workspace }}/include > coverage.txt
+                llvm-cov-17 show -output-dir reports -instr-profile oasis.profdata ${{ steps.strings.outputs.build-dir }}/tests/OasisTests -sources ${{ github.workspace }}/src ${{ github.workspace }}/include
 
             # Uploads the build, test, and code coverage artifacts.
-          - name: Comment on PR
-            uses: actions/github-script@v6
+          - name: Upload artifacts
+            uses: actions/upload-artifact@v3
             with:
-                script: |
-                    const fs = require('fs');
-                    const coverage_file = fs.readFileSync('${{ steps.strings.outputs.coverage-dir }}/coverage.txt');
-                    
-                    await github.rest.issues.createComment({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        issue_number: context.issue.number,
-                        body: '```\n' + coverage_file + '\n```'
-                    });
+                name: build-test-cover
+                path: |
+                    ${{ steps.strings.outputs.build-dir }}
+                    !${{ steps.strings.outputs.build-dir }}/_deps
+                    ${{ steps.strings.outputs.coverage-dir }}
+
+          - name: Upload PR number
+            uses: actions/upload-artifact@v3
+            with:
+                name: pr-number
+                path: ${{ steps.strings.outputs.pr-dir }}


### PR DESCRIPTION
This reverts commit 834ea90ae8793e47ec3e161fd30d4faad598709e. #75 broke the ability for code coverage reports to be commented on PRs opened from forks of this repo. This PR reverts that which should fix it.