### PR TITLE
[Feature] Add `UnaryExpression` and `Negate`

### DIFF
--- a/include/Oasis/Add.hpp
+++ b/include/Oasis/Add.hpp
@@ -30,8 +30,7 @@ public:
 
     [[nodiscard]] auto ToString() const -> std::string final;
 
-    static auto Specialize(const Expression& other) -> std::unique_ptr<Add>;
-    static auto Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Add>;
+    DECL_SPECIALIZE(Add)
 
     EXPRESSION_TYPE(Add)
     EXPRESSION_CATEGORY(Associative | Commutative)

--- a/include/Oasis/Expression.hpp
+++ b/include/Oasis/Expression.hpp
@@ -28,6 +28,8 @@ enum class ExpressionType {
     Divide,
     Exponent,
     Log,
+    Negate,
+    Sqrt,
 };
 
 /**
@@ -279,6 +281,10 @@ public:
     {                                                     \
         return category;                                  \
     }
+
+#define DECL_SPECIALIZE(type)                                                 \
+    static auto Specialize(const Expression& other) -> std::unique_ptr<type>; \
+    static auto Specialize(const Expression& other, tf::Subflow&) -> std::unique_ptr<type>;
 
 } // namespace Oasis
 

--- a/include/Oasis/Negate.hpp
+++ b/include/Oasis/Negate.hpp
@@ -1,0 +1,60 @@
+//
+// Created by Matthew McCall on 3/29/24.
+//
+
+#ifndef NEGATE_HPP
+#define NEGATE_HPP
+
+#include "Multiply.hpp"
+#include "fmt/core.h"
+
+#include "UnaryExpression.hpp"
+
+namespace Oasis {
+
+template <typename OperandT>
+class Negate final : public UnaryExpression<Negate, OperandT> {
+public:
+    Negate() = default;
+    Negate(const Negate& other)
+        : UnaryExpression<Negate, OperandT>(other)
+    {
+    }
+
+    explicit Negate(const OperandT& operand)
+        : UnaryExpression<Negate, OperandT>(operand)
+    {
+    }
+
+    [[nodiscard]] auto Simplify() const -> std::unique_ptr<Expression> override
+    {
+        return Multiply {
+            Real { -1.0 },
+            this->GetOperand()
+        }
+            .Simplify();
+    }
+
+    auto Simplify(tf::Subflow& subflow) const -> std::unique_ptr<Expression> override
+    {
+        return Multiply {
+            Real { -1.0 },
+            this->GetOperand()
+        }
+            .Simplify(subflow);
+    }
+
+    [[nodiscard]] auto ToString() const -> std::string override
+    {
+        return fmt::format("-({})", this->GetOperand().ToString());
+    }
+
+    IMPL_SPECIALIZE_UNARYEXPR(Negate, OperandT)
+
+    EXPRESSION_TYPE(Negate)
+    EXPRESSION_CATEGORY(None)
+};
+
+} // Oasis
+
+#endif // NEGATE_HPP

--- a/include/Oasis/UnaryExpression.hpp
+++ b/include/Oasis/UnaryExpression.hpp
@@ -16,7 +16,6 @@ class UnaryExpression : public Expression {
     using DerivedGeneralized = DerivedT<Expression>;
 
 public:
-
     UnaryExpression() = default;
 
     UnaryExpression(const UnaryExpression& other)
@@ -92,36 +91,35 @@ public:
         } else {
             this->op = std::make_unique<OperandT>(operand);
         }
-
     }
 
 protected:
     std::unique_ptr<OperandT> op;
 };
 
-#define IMPL_SPECIALIZE_UNARYEXPR(DerivedT, OperandT)                                             \
-    static auto Specialize(const Expression& other) -> std::unique_ptr<DerivedT>               \
-    {                                                                                             \
-        if (!other.Is<DerivedT>()) {                                                              \
-            return nullptr;                                                                       \
-        }                                                                                         \
-                                                                                                  \
-        auto specialized = std::make_unique<DerivedT<OperandT>>();                                \
-        std::unique_ptr<Expression> otherGeneralized = other.Generalize();                        \
-        const auto& otherUnary = dynamic_cast<const DerivedT<Expression>&>(*otherGeneralized);    \
-                                                                                                  \
-        if (auto operand = OperandT::Specialize(otherUnary.GetOperand()); operand != nullptr) {   \
-            specialized->op = std::move(operand);                                                 \
-            return specialized;                                                                   \
-        }                                                                                         \
-                                                                                                  \
-        return nullptr;                                                                           \
-    }                                                                                             \
-                                                                                                  \
-    static auto Specialize(const Expression& other, tf::Subflow&) -> std::unique_ptr<DerivedT> \
-    {                                                                                             \
-        /* TODO: Actually implement */                                                            \
-        return DerivedT<OperandT>::Specialize(other);                                             \
+#define IMPL_SPECIALIZE_UNARYEXPR(DerivedT, OperandT)                                           \
+    static auto Specialize(const Expression& other) -> std::unique_ptr<DerivedT>                \
+    {                                                                                           \
+        if (!other.Is<DerivedT>()) {                                                            \
+            return nullptr;                                                                     \
+        }                                                                                       \
+                                                                                                \
+        auto specialized = std::make_unique<DerivedT<OperandT>>();                              \
+        std::unique_ptr<Expression> otherGeneralized = other.Generalize();                      \
+        const auto& otherUnary = dynamic_cast<const DerivedT<Expression>&>(*otherGeneralized);  \
+                                                                                                \
+        if (auto operand = OperandT::Specialize(otherUnary.GetOperand()); operand != nullptr) { \
+            specialized->op = std::move(operand);                                               \
+            return specialized;                                                                 \
+        }                                                                                       \
+                                                                                                \
+        return nullptr;                                                                         \
+    }                                                                                           \
+                                                                                                \
+    static auto Specialize(const Expression& other, tf::Subflow&) -> std::unique_ptr<DerivedT>  \
+    {                                                                                           \
+        /* TODO: Actually implement */                                                          \
+        return DerivedT<OperandT>::Specialize(other);                                           \
     }
 
 } // Oasis

--- a/include/Oasis/UnaryExpression.hpp
+++ b/include/Oasis/UnaryExpression.hpp
@@ -1,0 +1,129 @@
+//
+// Created by Matthew McCall on 3/29/24.
+//
+
+#ifndef UNARYEXPRESSION_HPP
+#define UNARYEXPRESSION_HPP
+
+#include "Expression.hpp"
+
+namespace Oasis {
+
+template <template <IExpression> class DerivedT, IExpression OperandT>
+class UnaryExpression : public Expression {
+
+    using DerivedSpecialized = DerivedT<OperandT>;
+    using DerivedGeneralized = DerivedT<Expression>;
+
+public:
+
+    UnaryExpression() = default;
+
+    UnaryExpression(const UnaryExpression& other)
+        : Expression(other)
+    {
+        if (other.HasOperand()) {
+            SetOperand(other.GetOperand());
+        }
+    }
+
+    explicit UnaryExpression(const OperandT& operand)
+    {
+        SetOperand(operand);
+    }
+
+    [[nodiscard]] auto Copy() const -> std::unique_ptr<Expression> final
+    {
+        return std::make_unique<DerivedSpecialized>(*static_cast<const DerivedSpecialized*>(this));
+    }
+
+    auto Copy(tf::Subflow&) const -> std::unique_ptr<Expression> final
+    {
+        return std::make_unique<DerivedSpecialized>(*static_cast<const DerivedSpecialized*>(this));
+    }
+
+    [[nodiscard]] auto Equals(const Expression& other) const -> bool final
+    {
+        if (!other.Is<DerivedSpecialized>()) {
+            return false;
+        }
+
+        // generalize
+        const auto otherGeneralized = other.Generalize();
+        const auto& otherUnaryGeneralized = dynamic_cast<const DerivedGeneralized&>(*otherGeneralized);
+
+        return op->Equals(otherUnaryGeneralized.GetOperand());
+    }
+
+    [[nodiscard]] auto Generalize() const -> std::unique_ptr<Expression> final
+    {
+        return std::make_unique<DerivedGeneralized>(*this);
+    }
+
+    auto Generalize(tf::Subflow& subflow) const -> std::unique_ptr<Expression> final
+    {
+        return DerivedGeneralized { *this }.Copy(subflow);
+    }
+
+    auto GetOperand() const -> const OperandT&
+    {
+        return *op;
+    }
+
+    auto HasOperand() const -> bool
+    {
+        return op != nullptr;
+    }
+
+    [[nodiscard]] auto StructurallyEquivalent(const Expression& other) const -> bool final
+    {
+        return this->GetType() == other.GetType();
+    }
+
+    auto StructurallyEquivalent(const Expression& other, tf::Subflow&) const -> bool final
+    {
+        return this->GetType() == other.GetType();
+    }
+
+    auto SetOperand(const OperandT& operand) -> void
+    {
+        if constexpr (std::same_as<OperandT, Expression>) {
+            this->op = operand.Copy();
+        } else {
+            this->op = std::make_unique<OperandT>(operand);
+        }
+
+    }
+
+protected:
+    std::unique_ptr<OperandT> op;
+};
+
+#define IMPL_SPECIALIZE_UNARYEXPR(DerivedT, OperandT)                                             \
+    static auto Specialize(const Expression& other) -> std::unique_ptr<DerivedT>               \
+    {                                                                                             \
+        if (!other.Is<DerivedT>()) {                                                              \
+            return nullptr;                                                                       \
+        }                                                                                         \
+                                                                                                  \
+        auto specialized = std::make_unique<DerivedT<OperandT>>();                                \
+        std::unique_ptr<Expression> otherGeneralized = other.Generalize();                        \
+        const auto& otherUnary = dynamic_cast<const DerivedT<Expression>&>(*otherGeneralized);    \
+                                                                                                  \
+        if (auto operand = OperandT::Specialize(otherUnary.GetOperand()); operand != nullptr) {   \
+            specialized->op = std::move(operand);                                                 \
+            return specialized;                                                                   \
+        }                                                                                         \
+                                                                                                  \
+        return nullptr;                                                                           \
+    }                                                                                             \
+                                                                                                  \
+    static auto Specialize(const Expression& other, tf::Subflow&) -> std::unique_ptr<DerivedT> \
+    {                                                                                             \
+        /* TODO: Actually implement */                                                            \
+        return DerivedT<OperandT>::Specialize(other);                                             \
+    }
+
+} // Oasis
+
+#endif // UNARYEXPRESSION_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(Oasis_SOURCES
     Imaginary.cpp
     Log.cpp
     Multiply.cpp
+        Negate.cpp
     Real.cpp
     Subtract.cpp
     Undefined.cpp
@@ -30,8 +31,11 @@ set(Oasis_HEADERS
     ../include/Oasis/LeafExpression.hpp
     ../include/Oasis/Log.hpp
     ../include/Oasis/Multiply.hpp
+        ../include/Oasis/Negate.hpp
     ../include/Oasis/Real.hpp
     ../include/Oasis/Subtract.hpp
+        ../include/Oasis/UnaryExpression.hpp
+        ../include/Oasis/Undefined.hpp
     ../include/Oasis/Variable.hpp)
 
 # Adds a library target called "Oasis" to be built from source files.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ set(Oasis_SOURCES
     Imaginary.cpp
     Log.cpp
     Multiply.cpp
-        Negate.cpp
+    Negate.cpp
     Real.cpp
     Subtract.cpp
     Undefined.cpp
@@ -31,11 +31,11 @@ set(Oasis_HEADERS
     ../include/Oasis/LeafExpression.hpp
     ../include/Oasis/Log.hpp
     ../include/Oasis/Multiply.hpp
-        ../include/Oasis/Negate.hpp
+    ../include/Oasis/Negate.hpp
     ../include/Oasis/Real.hpp
     ../include/Oasis/Subtract.hpp
-        ../include/Oasis/UnaryExpression.hpp
-        ../include/Oasis/Undefined.hpp
+    ../include/Oasis/UnaryExpression.hpp
+    ../include/Oasis/Undefined.hpp
     ../include/Oasis/Variable.hpp)
 
 # Adds a library target called "Oasis" to be built from source files.

--- a/src/Negate.cpp
+++ b/src/Negate.cpp
@@ -1,0 +1,8 @@
+//
+// Created by Matthew McCall on 3/29/24.
+//
+
+#include "Oasis/Negate.hpp"
+
+namespace Oasis {
+} // Oasis

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(Oasis_TESTS
     ExponentTests.cpp
     LogTests.cpp
     MultiplyTests.cpp
+        NegateTests.cpp
     PolynomialTests.cpp
     SubtractTests.cpp)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ set(Oasis_TESTS
     ExponentTests.cpp
     LogTests.cpp
     MultiplyTests.cpp
-        NegateTests.cpp
+    NegateTests.cpp
     PolynomialTests.cpp
     SubtractTests.cpp)
 

--- a/tests/NegateTests.cpp
+++ b/tests/NegateTests.cpp
@@ -1,0 +1,19 @@
+//
+// Created by Matthew McCall on 4/5/24.
+//
+
+#include "catch2/catch_test_macros.hpp"
+
+#include <Oasis/Negate.hpp>
+
+TEST_CASE("Negate", "[Negate]")
+{
+    const Oasis::Negate negativeOne {
+        Oasis::Real { 1.0 }
+    };
+
+    const auto simplified = negativeOne.Simplify();
+
+    const Oasis::Real expected { -1.0 };
+    REQUIRE(simplified->Equals(expected));
+}


### PR DESCRIPTION
This PR adds UnaryExpression. An abstract node for expressions with a single operand such as negation, square roots, etc.

This PR also adds the `Negate` node, a convenience node to make tree insertion and balancing easier, for instance dealing with `Add`. This addresses #12.