### PR TITLE
[Feature] Variadic Constructor Parameters

### DIFF
--- a/include/Oasis/Add.hpp
+++ b/include/Oasis/Add.hpp
@@ -20,10 +20,7 @@ template <>
 class Add<
     Expression, Expression> : public BinaryExpression<Add> {
 public:
-    Add() = default;
-    Add(const Add<Expression, Expression>& other) = default;
-
-    Add(const Expression& addend1, const Expression& addend2);
+    using BinaryExpression::BinaryExpression;
 
     [[nodiscard]] auto Simplify() const -> std::unique_ptr<Expression> final;
     auto Simplify(tf::Subflow& subflow) const -> std::unique_ptr<Expression> final;

--- a/include/Oasis/BinaryExpression.hpp
+++ b/include/Oasis/BinaryExpression.hpp
@@ -101,7 +101,7 @@ public:
         SetLeastSigOp(leastSigOp);
     }
 
-    template<IExpression Op1T, IExpression Op2T, IExpression... OpsT>
+    template <IExpression Op1T, IExpression Op2T, IExpression... OpsT>
     BinaryExpression(const Op1T& op1, const Op2T& op2, const OpsT&... ops)
     {
         static_assert(IAssociativeAndCommutative<DerivedT>, "List initializer only supported for associative and commutative expressions");
@@ -110,7 +110,7 @@ public:
         std::vector<std::unique_ptr<Expression>> opsVec;
 
         for (auto opWrapper : std::vector<std::reference_wrapper<const Expression>> { static_cast<const Expression&>(op1), static_cast<const Expression&>(op2), (static_cast<const Expression&>(ops))... }) {
-            const Expression& operand= opWrapper.get();
+            const Expression& operand = opWrapper.get();
             opsVec.emplace_back(operand.Copy());
         }
 

--- a/include/Oasis/Multiply.hpp
+++ b/include/Oasis/Multiply.hpp
@@ -19,10 +19,7 @@ class Multiply;
 template <>
 class Multiply<Expression, Expression> : public BinaryExpression<Multiply> {
 public:
-    Multiply() = default;
-    Multiply(const Multiply<Expression, Expression>& other) = default;
-
-    Multiply(const Expression& multiplicand, const Expression& multiplier);
+    using BinaryExpression::BinaryExpression;
 
     [[nodiscard]] auto Simplify() const -> std::unique_ptr<Expression> final;
     auto Simplify(tf::Subflow& subflow) const -> std::unique_ptr<Expression> final;

--- a/src/Add.cpp
+++ b/src/Add.cpp
@@ -11,11 +11,6 @@
 
 namespace Oasis {
 
-Add<Expression>::Add(const Expression& addend1, const Expression& addend2)
-    : BinaryExpression(addend1, addend2)
-{
-}
-
 auto Add<Expression>::Simplify() const -> std::unique_ptr<Expression>
 {
     auto simplifiedAugend = mostSigOp ? mostSigOp->Simplify() : nullptr;

--- a/src/Divide.cpp
+++ b/src/Divide.cpp
@@ -203,13 +203,17 @@ auto Divide<Expression>::Simplify() const -> std::unique_ptr<Expression>
         }
     }
 
+    auto dividend = numeratorVals.size() == 1 ? std::move(numeratorVals.front()) : BuildFromVector<Multiply>(numeratorVals);
+    auto divisor = denominatorVals.size() == 1 ? std::move(denominatorVals.front()) : BuildFromVector<Multiply>(denominatorVals);
+
     // rebuild subtrees
-    if (!numeratorVals.empty() && !denominatorVals.empty())
-        return Divide { *(BuildFromVector<Multiply>(numeratorVals)), *(BuildFromVector<Multiply>(denominatorVals)) }.Generalize();
-    else if (!numeratorVals.empty() && denominatorVals.empty())
-        return BuildFromVector<Multiply>(numeratorVals);
-    else
-        return Divide { Real { 1.0 }, *(BuildFromVector<Multiply>(denominatorVals)) }.Generalize();
+    if (!dividend && divisor)
+        return Divide { Real { 1.0 }, *divisor }.Copy();
+
+    if (dividend && !divisor)
+        return dividend;
+
+    return Divide { *dividend, *divisor }.Copy();
 }
 
 auto Divide<Expression>::ToString() const -> std::string

--- a/src/Multiply.cpp
+++ b/src/Multiply.cpp
@@ -9,11 +9,6 @@
 
 namespace Oasis {
 
-Multiply<Expression>::Multiply(const Expression& minuend, const Expression& subtrahend)
-    : BinaryExpression(minuend, subtrahend)
-{
-}
-
 auto Multiply<Expression>::Simplify() const -> std::unique_ptr<Expression>
 {
     auto simplifiedMultiplicand = mostSigOp->Simplify();

--- a/tests/AddTests.cpp
+++ b/tests/AddTests.cpp
@@ -10,6 +10,8 @@
 #include "Oasis/Real.hpp"
 #include "Oasis/Variable.hpp"
 
+#include <functional>
+
 TEST_CASE("Addition", "[Add]")
 {
     Oasis::Add add {
@@ -261,4 +263,22 @@ TEST_CASE("Add Operator Overload", "[Add][Operator Overload]")
     REQUIRE(realSum != nullptr);
     REQUIRE(realSum->GetValue() == 3.0);
 
+}
+
+TEST_CASE("Variadic Add Constructor", "[Add]")
+{
+    const Oasis::Add<> add {
+        Oasis::Real { 1.0 },
+        Oasis::Real { 2.0 },
+        Oasis::Real { 3.0 },
+        Oasis::Real { 4.0 },
+        Oasis::Multiply {
+            Oasis::Real { 5.0 },
+            Oasis::Real { 6.0 } }
+    };
+
+    const Oasis::Real expected { 40.0 };
+
+    const auto simplified = add.Simplify();
+    REQUIRE(expected.Equals(*simplified));
 }

--- a/tests/DivideTests.cpp
+++ b/tests/DivideTests.cpp
@@ -29,7 +29,7 @@ TEST_CASE("Division", "[Divide]")
 
 TEST_CASE("Symbolic Division, equal variables", "[Division][Symbolic]")
 {
-    Oasis::Divide div {
+    const Oasis::Divide div {
         Oasis::Multiply {
             Oasis::Real { 2.0 },
             Oasis::Variable { "x" } },
@@ -39,25 +39,19 @@ TEST_CASE("Symbolic Division, equal variables", "[Division][Symbolic]")
     };
 
 
-    Oasis::Divide div2 {
-        Oasis::Multiply {
+    const Oasis::Divide div2 {
+        Oasis::Multiply<> {
             Oasis::Real { 2.0 },
-            Oasis::Multiply {
-                Oasis::Variable{ "z" },
-                Oasis::Multiply{
-                    Oasis::Variable{ "y" },
-                    Oasis::Variable{ "x" }
-                }
-            } },
-        Oasis::Multiply {
-                Oasis::Real { 1.0 },
-                Oasis::Multiply {
-                    Oasis::Variable{ "y" },
-                    Oasis::Multiply{
-                        Oasis::Variable{ "x" },
-                        Oasis::Variable{ "z" }
-                    }
-            }   }
+            Oasis::Variable{ "z" },
+            Oasis::Variable{ "y" },
+            Oasis::Variable{ "x" }
+        },
+        Oasis::Multiply<> {
+            Oasis::Real { 1.0 },
+            Oasis::Variable{ "y" },
+            Oasis::Variable{ "x" },
+            Oasis::Variable{ "z" }
+            }
         };
 
     auto simplified = div.Simplify();

--- a/tests/DivideTests.cpp
+++ b/tests/DivideTests.cpp
@@ -61,16 +61,12 @@ TEST_CASE("Symbolic Division, equal variables", "[Division][Symbolic]")
         };
 
     auto simplified = div.Simplify();
-    REQUIRE(simplified->Is<Oasis::Real>());
-    auto simplifiedReal = dynamic_cast<Oasis::Real&>(*simplified);
-    REQUIRE(simplifiedReal.GetValue() == 2.0);
-
+    REQUIRE(simplified);
+    REQUIRE(simplified->Equals(Oasis::Real { 2.0 }));
 
     auto simplified2 = div2.Simplify();
-    CAPTURE(simplified2->ToString());
-    REQUIRE(simplified2->Is<Oasis::Real>());
-    auto simplifiedReal2 = dynamic_cast<Oasis::Real&>(*simplified2);
-    REQUIRE(simplifiedReal2.GetValue() == 2.0);
+    REQUIRE(simplified2);
+    REQUIRE(simplified2->Equals(Oasis::Real { 2.0 }));
 }
 
 

--- a/tests/MultiplyTests.cpp
+++ b/tests/MultiplyTests.cpp
@@ -4,6 +4,7 @@
 
 #include "catch2/catch_test_macros.hpp"
 
+#include "Oasis/Add.hpp"
 #include "Oasis/Exponent.hpp"
 #include "Oasis/Imaginary.hpp"
 #include "Oasis/Multiply.hpp"
@@ -121,4 +122,23 @@ TEST_CASE("Multiply Operator Overload", "[Multiply][Operator Overload]")
 
     REQUIRE(realSum != nullptr);
     REQUIRE(realSum->GetValue() == 2.0);
+}
+
+TEST_CASE("Variadic Multiply Constructor", "[Multiply]")
+{
+    const Oasis::Multiply<> multiply {
+        Oasis::Real { 1.0 },
+        Oasis::Real { 2.0 },
+        Oasis::Real { 3.0 },
+        Oasis::Real { 4.0 },
+        Oasis::Add<> {
+            Oasis::Real { 5.0 },
+            Oasis::Real { 6.0 },
+                Oasis::Real { 7.0 }}
+    };
+
+    const Oasis::Real expected { 432.0 };
+
+    const auto simplified = multiply.Simplify();
+    REQUIRE(expected.Equals(*simplified));
 }


### PR DESCRIPTION
This PR makes so that you don't have to nest arguments for associative and commutative expression like the example below:
```cpp
Multiply {
  Real { 2.0 },
  Multiply {
    Variable { "x" },
    Variable { "y" } } };
```
Now you can simply do:
```cpp
Multiply<> {
  Real { 2.0 },
  Variable { "x" },
  Variable { "y" } };
```
Note type deduction for specialized expression fails when using this, thus it is only available for generalized expressions (hence the `<>`).