### PR TITLE
[Feature] Add Parsing from String and Serialization to MathML

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -75,7 +75,7 @@ jobs:
                 -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
                 -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
                 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-              -Dtinyxml2_BUILD_TESTING=OFF
+                -Dtinyxml2_BUILD_TESTING=OFF
 
             # Builds Oasis with the given configuration.
           - name: Build Oasis

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -60,7 +60,7 @@ jobs:
 
             # Installs LLVM 17 on the Ubuntu runner.
           - name: Install LLVM 17
-            if: ${{ matrix.os == 'ubuntu-latest' }}
+            if: ${{ matrix.c_compiler == 'clang-17' }}
             run: |
                 wget https://apt.llvm.org/llvm.sh
                 chmod +x llvm.sh
@@ -75,6 +75,7 @@ jobs:
                 -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
                 -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
                 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+              -Dtinyxml2_BUILD_TESTING=OFF
 
             # Builds Oasis with the given configuration.
           - name: Build Oasis

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,9 @@ FetchContent_Declare(
     GIT_TAG 10.0.0)
 
 FetchContent_Declare(
-        tinyxml2
-        GIT_REPOSITORY https://github.com/leethomason/tinyxml2
-        GIT_TAG 10.0.0)
+    tinyxml2
+    GIT_REPOSITORY https://github.com/leethomason/tinyxml2
+    GIT_TAG 10.0.0)
 
 FetchContent_MakeAvailable(Catch2 fmt tinyxml2)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,12 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
     GIT_TAG 10.0.0)
 
-FetchContent_MakeAvailable(Catch2 fmt)
+FetchContent_Declare(
+        tinyxml2
+        GIT_REPOSITORY https://github.com/leethomason/tinyxml2
+        GIT_TAG 10.0.0)
+
+FetchContent_MakeAvailable(Catch2 fmt tinyxml2)
 
 # Processes the CMakeLists.txt for dependencies that need special handling.
 add_subdirectory(cmake/FetchEigen)

--- a/include/Oasis/Add.hpp
+++ b/include/Oasis/Add.hpp
@@ -30,6 +30,8 @@ public:
 
     [[nodiscard]] auto ToString() const -> std::string final;
 
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* final;
+
     static auto Specialize(const Expression& other) -> std::unique_ptr<Add>;
     static auto Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Add>;
 
@@ -56,11 +58,6 @@ public:
     Add(const AugendT& addend1, const AddendT& addend2)
         : BinaryExpression<Add, AugendT, AddendT>(addend1, addend2)
     {
-    }
-
-    [[nodiscard]] auto ToString() const -> std::string final
-    {
-        return fmt::format("({} + {})", this->mostSigOp->ToString(), this->leastSigOp->ToString());
     }
 
     IMPL_SPECIALIZE(Add, AugendT, AddendT)

--- a/include/Oasis/BinaryExpression.hpp
+++ b/include/Oasis/BinaryExpression.hpp
@@ -205,7 +205,7 @@ public:
         return simplified;
     }
 
-    [[nodiscard]] auto StructurallyEquivalent(const Expression& other) const -> bool override
+    [[nodiscard]] auto StructurallyEquivalent(const Expression& other) const -> bool final
     {
         if (this->GetType() != other.GetType()) {
             return false;
@@ -233,7 +233,7 @@ public:
         return true;
     }
 
-    auto StructurallyEquivalent(const Expression& other, tf::Subflow& subflow) const -> bool override
+    auto StructurallyEquivalent(const Expression& other, tf::Subflow& subflow) const -> bool final
     {
         if (this->GetType() != other.GetType()) {
             return false;
@@ -429,7 +429,16 @@ public:
 
     auto operator=(const BinaryExpression& other) -> BinaryExpression& = default;
 
-protected:
+    [[nodiscard]] std::string ToString() const override
+    {
+        return Generalize()->ToString();
+    }
+
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* override
+    {
+        return Generalize()->ToMathMLElement(doc);
+    }
+
     std::unique_ptr<MostSigOpT> mostSigOp;
     std::unique_ptr<LeastSigOpT> leastSigOp;
 };

--- a/include/Oasis/Divide.hpp
+++ b/include/Oasis/Divide.hpp
@@ -29,6 +29,8 @@ public:
 
     [[nodiscard]] auto ToString() const -> std::string final;
 
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* final;
+
     static auto Specialize(const Expression& other) -> std::unique_ptr<Divide>;
     static auto Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Divide>;
 
@@ -55,11 +57,6 @@ public:
     Divide(const DividendT& addend1, const DivisorT& addend2)
         : BinaryExpression<Divide, DividendT, DivisorT>(addend1, addend2)
     {
-    }
-
-    [[nodiscard]] auto ToString() const -> std::string final
-    {
-        return fmt::format("({} + {})", this->mostSigOp->ToString(), this->leastSigOp->ToString());
     }
 
     IMPL_SPECIALIZE(Divide, DividendT, DivisorT)

--- a/include/Oasis/Exponent.hpp
+++ b/include/Oasis/Exponent.hpp
@@ -30,6 +30,8 @@ public:
 
     [[nodiscard]] auto ToString() const -> std::string final;
 
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* final;
+
     static auto Specialize(const Expression& other) -> std::unique_ptr<Exponent>;
     static auto Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Exponent>;
 
@@ -56,11 +58,6 @@ public:
     Exponent(const BaseT& base, const PowerT& power)
         : BinaryExpression<Exponent, BaseT, PowerT>(base, power)
     {
-    }
-
-    [[nodiscard]] auto ToString() const -> std::string final
-    {
-        return fmt::format("({}^{})", this->mostSigOp->ToString(), this->leastSigOp->ToString());
     }
 
     IMPL_SPECIALIZE(Exponent, BaseT, PowerT)

--- a/include/Oasis/Expression.hpp
+++ b/include/Oasis/Expression.hpp
@@ -1,10 +1,10 @@
 #ifndef OASIS_EXPRESSION_HPP
 #define OASIS_EXPRESSION_HPP
 
-#include <concepts>
-#include <memory>
 #include <string>
 #include <vector>
+
+#include "tinyxml2.h"
 
 namespace tf {
 class Subflow;
@@ -254,6 +254,19 @@ public:
      * @return The string representation of this expression.
      */
     [[nodiscard]] virtual std::string ToString() const = 0;
+
+    /**
+     * Converts this expression to a MathML string.
+     * @return The MathML representation of this expression.
+     */
+    auto ToMathML() const -> std::string;
+
+    /**
+     *
+     * @param doc The XML document.
+     * @return The XML element.
+     */
+    virtual auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* = 0;
 
     virtual ~Expression() = default;
 };

--- a/include/Oasis/Expression.hpp
+++ b/include/Oasis/Expression.hpp
@@ -1,6 +1,7 @@
 #ifndef OASIS_EXPRESSION_HPP
 #define OASIS_EXPRESSION_HPP
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/include/Oasis/FromString.hpp
+++ b/include/Oasis/FromString.hpp
@@ -1,0 +1,13 @@
+//
+// Created by Matthew McCall on 4/21/24.
+//
+
+#ifndef FROMSTRING_HPP
+#define FROMSTRING_HPP
+
+namespace Oasis {
+auto FromInFix(const std::string& str) -> std::unique_ptr<Expression>;
+
+}
+
+#endif // FROMSTRING_HPP

--- a/include/Oasis/Imaginary.hpp
+++ b/include/Oasis/Imaginary.hpp
@@ -24,6 +24,8 @@ public:
 
     [[nodiscard]] auto ToString() const -> std::string final;
 
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* final;
+
     static auto Specialize(const Expression& other) -> std::unique_ptr<Imaginary>;
     static auto Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Imaginary>;
 };

--- a/include/Oasis/Log.hpp
+++ b/include/Oasis/Log.hpp
@@ -29,6 +29,8 @@ public:
 
     [[nodiscard]] auto ToString() const -> std::string final;
 
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* override;
+
     static auto Specialize(const Expression& other) -> std::unique_ptr<Log>;
     static auto Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Log>;
 

--- a/include/Oasis/Multiply.hpp
+++ b/include/Oasis/Multiply.hpp
@@ -29,6 +29,8 @@ public:
 
     [[nodiscard]] auto ToString() const -> std::string final;
 
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* override;
+
     static auto Specialize(const Expression& other) -> std::unique_ptr<Multiply>;
     static auto Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Multiply>;
 
@@ -55,11 +57,6 @@ public:
     Multiply(const MultiplicandT& addend1, const MultiplierT& addend2)
         : BinaryExpression<Multiply, MultiplicandT, MultiplierT>(addend1, addend2)
     {
-    }
-
-    [[nodiscard]] auto ToString() const -> std::string final
-    {
-        return fmt::format("({} + {})", this->mostSigOp->ToString(), this->leastSigOp->ToString());
     }
 
     IMPL_SPECIALIZE(Multiply, MultiplicandT, MultiplierT)

--- a/include/Oasis/Negate.hpp
+++ b/include/Oasis/Negate.hpp
@@ -49,6 +49,31 @@ public:
         return fmt::format("-({})", this->GetOperand().ToString());
     }
 
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* override
+    {
+        // mrow
+        tinyxml2::XMLElement* const mrow = doc.NewElement("mrow");
+
+        // mo
+        tinyxml2::XMLElement* const mo = doc.NewElement("mo");
+        mo->SetText("-");
+        mrow->InsertEndChild(mo);
+
+        // (
+        tinyxml2::XMLElement* const leftParen = doc.NewElement("mo");
+        leftParen->SetText("(");
+        mrow->InsertEndChild(leftParen);
+
+        mrow->InsertEndChild(this->op->ToMathMLElement(doc));
+
+        // )
+        tinyxml2::XMLElement* const rightParen = doc.NewElement("mo");
+        rightParen->SetText(")");
+        mrow->InsertEndChild(rightParen);
+
+        return mrow;
+    }
+
     IMPL_SPECIALIZE_UNARYEXPR(Negate, OperandT)
 
     EXPRESSION_TYPE(Negate)

--- a/include/Oasis/Real.hpp
+++ b/include/Oasis/Real.hpp
@@ -32,6 +32,8 @@ public:
 
     [[nodiscard]] auto ToString() const -> std::string final;
 
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* final;
+
     static auto Specialize(const Expression& other) -> std::unique_ptr<Real>;
     static auto Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Real>;
 

--- a/include/Oasis/Subtract.hpp
+++ b/include/Oasis/Subtract.hpp
@@ -29,6 +29,8 @@ public:
 
     [[nodiscard]] auto ToString() const -> std::string final;
 
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* final;
+
     static auto Specialize(const Expression& other) -> std::unique_ptr<Subtract>;
     static auto Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Subtract>;
 
@@ -55,11 +57,6 @@ public:
     Subtract(const MinuendT& addend1, const SubtrahendT& addend2)
         : BinaryExpression<Subtract, MinuendT, SubtrahendT>(addend1, addend2)
     {
-    }
-
-    [[nodiscard]] auto ToString() const -> std::string final
-    {
-        return fmt::format("({} - {})", this->mostSigOp->ToString(), this->leastSigOp->ToString());
     }
 
     IMPL_SPECIALIZE(Subtract, MinuendT, SubtrahendT)

--- a/include/Oasis/Undefined.hpp
+++ b/include/Oasis/Undefined.hpp
@@ -24,6 +24,8 @@ public:
 
     [[nodiscard]] auto ToString() const -> std::string final;
 
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* final;
+
     static auto Specialize(const Expression& other) -> std::unique_ptr<Undefined>;
     static auto Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Undefined>;
 

--- a/include/Oasis/Variable.hpp
+++ b/include/Oasis/Variable.hpp
@@ -38,6 +38,8 @@ public:
 
     [[nodiscard]] auto ToString() const -> std::string final;
 
+    auto ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement* final;
+
     static auto Specialize(const Expression& other) -> std::unique_ptr<Variable>;
     static auto Specialize(const Expression& other, tf::Subflow& subflow) -> std::unique_ptr<Variable>;
 

--- a/src/Add.cpp
+++ b/src/Add.cpp
@@ -206,6 +206,28 @@ auto Add<Expression>::ToString() const -> std::string
     return fmt::format("({} + {})", mostSigOp->ToString(), leastSigOp->ToString());
 }
 
+auto Add<Expression>::ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement*
+{
+    // create mrow element
+    tinyxml2::XMLElement* mrow = doc.NewElement("mrow");
+
+    std::vector<std::unique_ptr<Expression>> ops;
+    Flatten(ops);
+
+    for (const auto& op : ops) {
+        mrow->InsertEndChild(op->ToMathMLElement(doc));
+        // add + mo
+        tinyxml2::XMLElement* mo = doc.NewElement("mo");
+        mo->SetText("+");
+        mrow->InsertEndChild(mo);
+    }
+
+    // remove last mo
+    mrow->DeleteChild(mrow->LastChild());
+
+    return mrow;
+}
+
 auto Add<Expression>::Simplify(tf::Subflow& subflow) const -> std::unique_ptr<Expression>
 {
     std::unique_ptr<Expression> simplifiedAugend, simplifiedAddend;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,6 @@ endif()
 
 target_compile_features(Oasis PUBLIC cxx_std_20)
 target_include_directories(Oasis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_link_libraries(Oasis PUBLIC fmt::fmt Eigen3::Eigen Taskflow)
+target_link_libraries(Oasis PUBLIC fmt::fmt Eigen3::Eigen Taskflow tinyxml2::tinyxml2)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${Oasis_SOURCES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,7 @@ endif()
 
 target_compile_features(Oasis PUBLIC cxx_std_20)
 target_include_directories(Oasis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_link_libraries(Oasis PUBLIC fmt::fmt Eigen3::Eigen Taskflow tinyxml2::tinyxml2)
+target_link_libraries(Oasis PUBLIC fmt::fmt Eigen3::Eigen Taskflow
+                                   tinyxml2::tinyxml2)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${Oasis_SOURCES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,8 @@ set(Oasis_SOURCES
     Imaginary.cpp
     Log.cpp
     Multiply.cpp
+    Parsers/SExpression/SExpression.cpp
+    Parsers/SExpression/SExpression.hpp
     Real.cpp
     Subtract.cpp
     Undefined.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,8 +17,8 @@ set(Oasis_SOURCES
     Log.cpp
     Multiply.cpp
     Negate.cpp
-    Parsers/SExpression/SExpression.cpp
-    Parsers/SExpression/SExpression.hpp
+#    Parsers/SExpression/SExpression.cpp
+#    Parsers/SExpression/SExpression.hpp
     Real.cpp
     Subtract.cpp
     Undefined.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(Oasis_SOURCES
     Divide.cpp
     Exponent.cpp
     Expression.cpp
+        FromString.cpp
     Imaginary.cpp
     Log.cpp
     Multiply.cpp
@@ -28,6 +29,7 @@ set(Oasis_HEADERS
     ../include/Oasis/Divide.hpp
     ../include/Oasis/Exponent.hpp
     ../include/Oasis/Expression.hpp
+        ../include/Oasis/FromString.hpp
     ../include/Oasis/Imaginary.hpp
     ../include/Oasis/LeafExpression.hpp
     ../include/Oasis/Log.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,8 +17,7 @@ set(Oasis_SOURCES
     Log.cpp
     Multiply.cpp
     Negate.cpp
-#    Parsers/SExpression/SExpression.cpp
-#    Parsers/SExpression/SExpression.hpp
+    # Parsers/SExpression/SExpression.cpp Parsers/SExpression/SExpression.hpp
     Real.cpp
     Subtract.cpp
     Undefined.cpp

--- a/src/Divide.cpp
+++ b/src/Divide.cpp
@@ -217,6 +217,16 @@ auto Divide<Expression>::ToString() const -> std::string
     return fmt::format("({} / {})", mostSigOp->ToString(), leastSigOp->ToString());
 }
 
+tinyxml2::XMLElement* Divide<Expression, Expression>::ToMathMLElement(tinyxml2::XMLDocument& doc) const
+{
+    tinyxml2::XMLElement* element = doc.NewElement("mfrac");
+
+    element->InsertEndChild(mostSigOp->ToMathMLElement(doc));
+    element->InsertEndChild(leastSigOp->ToMathMLElement(doc));
+
+    return element;
+}
+
 auto Divide<Expression>::Simplify(tf::Subflow& subflow) const -> std::unique_ptr<Expression>
 {
     std::unique_ptr<Expression> simplifiedDividend, simplifiedDivisor;

--- a/src/Exponent.cpp
+++ b/src/Exponent.cpp
@@ -101,6 +101,19 @@ auto Exponent<Expression>::ToString() const -> std::string
     return fmt::format("({}^{})", mostSigOp->ToString(), leastSigOp->ToString());
 }
 
+tinyxml2::XMLElement* Exponent<Expression, Expression>::ToMathMLElement(tinyxml2::XMLDocument& doc) const
+{
+    tinyxml2::XMLElement* element = doc.NewElement("msup");
+
+    tinyxml2::XMLElement* baseElement = mostSigOp->ToMathMLElement(doc);
+    tinyxml2::XMLElement* powerElement = leastSigOp->ToMathMLElement(doc);
+
+    element->InsertEndChild(baseElement);
+    element->InsertEndChild(powerElement);
+
+    return element;
+}
+
 auto Exponent<Expression>::Simplify(tf::Subflow& subflow) const -> std::unique_ptr<Expression>
 {
     std::unique_ptr<Expression> simplifiedBase, simplifiedPower;

--- a/src/Expression.cpp
+++ b/src/Expression.cpp
@@ -283,6 +283,18 @@ auto Expression::StructurallyEquivalentAsync(const Expression& other) const -> b
     return equivalent;
 }
 
+auto Expression::ToMathML() const -> std::string
+{
+    tinyxml2::XMLDocument doc;
+    auto* root = ToMathMLElement(doc);
+    doc.InsertFirstChild(root);
+
+    tinyxml2::XMLPrinter printer;
+    doc.Print(&printer);
+
+    return printer.CStr();
+}
+
 } // namespace Oasis
 std::unique_ptr<Oasis::Expression> operator+(const std::unique_ptr<Oasis::Expression>& lhs, const std::unique_ptr<Oasis::Expression>& rhs)
 {

--- a/src/FromString.cpp
+++ b/src/FromString.cpp
@@ -1,0 +1,249 @@
+//
+// Created by Matthew McCall on 4/21/24.
+//
+#include <memory>
+#include <regex>
+#include <sstream>
+#include <stack>
+
+#include <Oasis/Add.hpp>
+#include <Oasis/Divide.hpp>
+#include <Oasis/Exponent.hpp>
+#include <Oasis/Log.hpp>
+#include <Oasis/Multiply.hpp>
+#include <Oasis/Real.hpp>
+#include <Oasis/Subtract.hpp>
+
+#include "Oasis/FromString.hpp"
+
+namespace {
+
+int prec(const char c)
+{
+    if (c == '^')
+        return 3;
+    if (c == '*' || c == '/')
+        return 2;
+    if (c == '+' || c == '-')
+        return 1;
+    return -1;
+}
+
+template <typename T>
+void setOps(T& exp, const std::unique_ptr<Oasis::Expression>& op1, const std::unique_ptr<Oasis::Expression>& op2)
+{
+    if (op1) {
+        exp.SetMostSigOp(*op1);
+    }
+    if (op2) {
+        exp.SetLeastSigOp(*op2);
+    }
+}
+
+void processOp(std::stack<std::string>& ops, std::stack<std::unique_ptr<Oasis::Expression>>& st)
+{
+    const auto right = std::move(st.top());
+    st.pop();
+    const auto left = std::move(st.top());
+    st.pop();
+
+    // if (ops.top() == "log") {
+    //     st.pop();
+    //     st.push(std::make_unique<Oasis::Log<>>(*left, *right));
+    // } else {
+    const auto op = ops.top();
+    assert(op.size() == 1);
+
+    std::unique_ptr<Oasis::Expression> opExp;
+
+    switch (op[0]) {
+    case '+': {
+        Oasis::Add<> add;
+        setOps(add, left, right);
+        opExp = add.Copy();
+    } break;
+    case '-': {
+        Oasis::Subtract<> subtract;
+        setOps(subtract, left, right);
+        opExp = subtract.Copy();
+    } break;
+    case '*': {
+        Oasis::Multiply<> multiply;
+        setOps(multiply, left, right);
+        opExp = multiply.Copy();
+    } break;
+    case '/': {
+        Oasis::Divide<> divide;
+        setOps(divide, left, right);
+        opExp = divide.Copy();
+    } break;
+    case '^': {
+        Oasis::Exponent<> exponent;
+        setOps(exponent, left, right);
+        opExp = exponent.Copy();
+    }
+    default:
+        throw std::runtime_error("Unknown operator encountered: " + op);
+    }
+
+    st.emplace(std::move(opExp));
+    // }
+    ops.pop();
+}
+
+void processFunction(std::stack<std::unique_ptr<Oasis::Expression>>& st, const std::string& function_token)
+{
+    // If we have a function active, the second operand has just been pushed onto the stack
+    auto second_operand = std::move(st.top());
+    st.pop();
+    auto first_operand = std::move(st.top());
+    st.pop();
+
+    std::unique_ptr<Oasis::Expression> func;
+
+    if (function_token == "log") {
+        Oasis::Log<> log;
+        setOps(log, first_operand, second_operand);
+        func = log.Copy();
+    } else {
+        throw std::runtime_error("Unknown function encountered: " + function_token);
+    }
+
+    st.emplace(std::move(func));
+}
+
+std::vector<std::string> tokenizeMultiplicands(const std::string& expression)
+{
+    // Insert '*' between digits and letters, and letters and digits
+    std::string explicit_multiplication;
+    for (size_t i = 0; i < expression.size(); i++) {
+        explicit_multiplication += expression[i];
+        if (i < expression.size() - 1) {
+            bool is_digit = isdigit(expression[i]);
+            bool is_letter = isalpha(expression[i]);
+            bool is_digit_next = isdigit(expression[i + 1]);
+            bool is_letter_next = isalpha(expression[i + 1]);
+
+            if ((is_digit && is_letter_next) || (is_letter && is_digit_next)) {
+                explicit_multiplication += '*';
+            }
+
+            if (is_letter && is_letter_next) {
+                explicit_multiplication += '*';
+            }
+        }
+    }
+
+    // Tokenize on '*'
+    std::vector<std::string> tokens;
+    std::string buffer;
+    bool inside_braces = false;
+
+    for (char c : explicit_multiplication) {
+        if (c == '{')
+            inside_braces = true;
+        if (c == '}')
+            inside_braces = false;
+
+        if (c == '*' && !inside_braces) {
+            tokens.push_back(buffer);
+            buffer.clear();
+        } else {
+            buffer += c;
+        }
+    }
+
+    tokens.push_back(buffer); // push back the last token
+
+    return tokens;
+}
+
+template <typename First, typename... T>
+bool is_in(First&& first, T&&... t)
+{
+    return ((first == t) || ...);
+}
+
+bool is_operator(const std::string& token) { return is_in(token, "+", "-", "*", "/", "^"); }
+
+bool is_function(const std::string& token) { return is_in(token, "log"); }
+
+bool is_number(const std::string& token) { return std::regex_match(token, std::regex(R"(^-?\d+(\.\d+)?$)")); }
+
+std::unique_ptr<Oasis::Expression> multiplyFromVariables(const std::vector<std::string>& tokens)
+{
+    std::vector<std::unique_ptr<Oasis::Expression>> multiplicands;
+    std::ranges::transform(tokens, std::back_inserter(multiplicands), [](auto token) -> std::unique_ptr<Oasis::Expression> {
+        if (is_number(token)) {
+            return std::make_unique<Oasis::Real>(std::stof(token));
+        }
+
+        return std::make_unique<Oasis::Variable>(token);
+    });
+
+    return Oasis::BuildFromVector<Oasis::Multiply>(multiplicands);
+}
+
+}
+
+namespace Oasis {
+class Expression;
+
+auto FromInFix(const std::string& str) -> std::unique_ptr<Expression>
+{
+    // Based of Dijkstra's Shunting Yard
+
+    std::stack<std::unique_ptr<Expression>> st;
+    std::stack<std::string> ops;
+
+    std::string token, function_token;
+    std::stringstream ss(str);
+
+    while (ss >> token) {
+        // Operand
+        if (is_number(token)) {
+            st.push(std::make_unique<Real>(std::stof(token)));
+        }
+        // '(' or function
+        else if (token == "(" || is_function(token)) {
+            ops.push(token);
+        }
+        // ','
+        else if (token == ",") {
+            // function_active = true;
+            while (!ops.empty() && ops.top() != "(") {
+                processOp(ops, st);
+            }
+        }
+        // ')'
+        else if (token == ")") {
+            while (!ops.empty() && ops.top() != "(") {
+                processOp(ops, st);
+            }
+            ops.pop(); // pop '('
+            if (!ops.empty() && is_function(ops.top())) {
+                std::string func = ops.top();
+                ops.pop();
+                processFunction(st, func);
+            }
+        }
+        // Operator
+        else if (is_operator(token)) {
+            while (!ops.empty() && prec(ops.top()[0]) >= prec(token[0])) {
+                processOp(ops, st);
+            }
+            ops.push(token);
+        } else if (ss.peek() != '(') {
+            st.push(multiplyFromVariables(tokenizeMultiplicands(token)));
+        }
+    }
+
+    // Process remaining ops
+    while (!ops.empty()) {
+        processOp(ops, st);
+    }
+
+    return st.top()->Copy(); // root of the expression tree
+}
+
+}

--- a/src/FromString.cpp
+++ b/src/FromString.cpp
@@ -81,6 +81,7 @@ void processOp(std::stack<std::string>& ops, std::stack<std::unique_ptr<Oasis::E
         Oasis::Exponent<> exponent;
         setOps(exponent, left, right);
         opExp = exponent.Copy();
+        break;
     }
     default:
         throw std::runtime_error("Unknown operator encountered: " + op);

--- a/src/Imaginary.cpp
+++ b/src/Imaginary.cpp
@@ -17,6 +17,13 @@ auto Imaginary::ToString() const -> std::string
     return "i";
 }
 
+auto Imaginary::ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement*
+{
+    tinyxml2::XMLElement* const element = doc.NewElement("mi");
+    element->SetText(ToString().c_str());
+    return element;
+}
+
 auto Imaginary::Specialize(const Expression& other) -> std::unique_ptr<Imaginary>
 {
     return other.Is<Imaginary>() ? std::make_unique<Imaginary>(dynamic_cast<const Imaginary&>(other)) : nullptr;

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -73,6 +73,38 @@ auto Log<Expression>::ToString() const -> std::string
     return fmt::format("log({}, {})", mostSigOp->ToString(), leastSigOp->ToString());
 }
 
+tinyxml2::XMLElement* Log<Expression, Expression>::ToMathMLElement(tinyxml2::XMLDocument& doc) const
+{
+    // mrow
+    tinyxml2::XMLElement* const mrow = doc.NewElement("mrow");
+
+    // log
+    tinyxml2::XMLElement* const sub = doc.NewElement("msub");
+
+    tinyxml2::XMLElement* const log = doc.NewElement("mi");
+    log->SetText("log");
+
+    tinyxml2::XMLElement* const base = leastSigOp->ToMathMLElement(doc);
+
+    sub->InsertFirstChild(log);
+    sub->InsertEndChild(base);
+    mrow->InsertFirstChild(sub);
+
+    // (
+    tinyxml2::XMLElement* const leftParen = doc.NewElement("mo");
+    leftParen->SetText("(");
+
+    // )
+    tinyxml2::XMLElement* const rightParen = doc.NewElement("mo");
+    rightParen->SetText(")");
+
+    mrow->InsertEndChild(leftParen);
+    mrow->InsertEndChild(leastSigOp->ToMathMLElement(doc));
+    mrow->InsertEndChild(rightParen);
+
+    return mrow;
+}
+
 auto Log<Expression>::Specialize(const Expression& other) -> std::unique_ptr<Log>
 {
     if (!other.Is<Oasis::Log>()) {

--- a/src/Multiply.cpp
+++ b/src/Multiply.cpp
@@ -263,6 +263,28 @@ auto Multiply<Expression>::ToString() const -> std::string
     return fmt::format("({} * {})", mostSigOp->ToString(), leastSigOp->ToString());
 }
 
+auto Multiply<Expression>::ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement*
+{
+    // create mrow element
+    tinyxml2::XMLElement* mrow = doc.NewElement("mrow");
+
+    std::vector<std::unique_ptr<Expression>> ops;
+    Flatten(ops);
+
+    for (const auto& op : ops) {
+        mrow->InsertEndChild(op->ToMathMLElement(doc));
+        // add * mo
+        tinyxml2::XMLElement* mo = doc.NewElement("mo");
+        mo->SetText("*");
+        mrow->InsertEndChild(mo);
+    }
+
+    // remove last mo
+    mrow->DeleteChild(mrow->LastChild());
+
+    return mrow;
+}
+
 auto Multiply<Expression>::Simplify(tf::Subflow& subflow) const -> std::unique_ptr<Expression>
 {
     std::unique_ptr<Expression> simplifiedMultiplicand, simplifiedMultiplier;

--- a/src/Parsers/SExpression/SExpression.cpp
+++ b/src/Parsers/SExpression/SExpression.cpp
@@ -1,0 +1,67 @@
+//
+// Created by Matthew McCall on 4/9/24.
+//
+
+#include <cctype>
+#include <sstream>
+#include <stack>
+
+#include "SExpression.hpp"
+
+namespace Oasis::t3 {
+
+Sexp::Sexp(const std::string& str)
+{
+    std::string strWithNoParens = str;
+
+    // Check if it is surrounded by parenthesis
+    if (str.starts_with("(") && str.ends_with(")")) {
+        strWithNoParens = str.substr(1, str.length() - 2);
+    } else if (str.starts_with("(") || str.ends_with(")")) {
+        BAD_SEXP = true;
+        return;
+    }
+
+    std::stack<std::reference_wrapper<Sexp>> opStack;
+    opStack.emplace(*this);
+
+    std::istringstream stream { strWithNoParens };
+    stream >> label;
+
+    std::string arg;
+    while (stream >> arg) {
+        Sexp& current = opStack.top().get();
+
+        if (arg.starts_with("(")) {
+            opStack.emplace(current.operands.emplace_back(arg.substr(1, arg.length())));
+            continue;
+        }
+
+        // what if we had "4)2)"?
+        auto closingParensPos = arg.find(')');
+        while (closingParensPos != std::string::npos) {
+            // get the "4"
+            if (auto argBeforeClosingParens = arg.substr(0, closingParensPos); !argBeforeClosingParens.empty()) {
+                current.operands.emplace_back(argBeforeClosingParens);
+            }
+            opStack.pop();
+            // make sure this isn't the last parens
+            if (closingParensPos + 1 >= arg.size()) {
+                goto loop_end;
+            }
+            // get the "2)"
+            arg = arg.substr(closingParensPos + 1, arg.size());
+            closingParensPos = arg.find(')');
+        }
+
+        current.operands.emplace_back(arg);
+        if (operands.back().BAD_SEXP) {
+            operands.clear();
+            BAD_SEXP = true;
+            return;
+        }
+loop_end: {}
+    }
+}
+
+}

--- a/src/Parsers/SExpression/SExpression.hpp
+++ b/src/Parsers/SExpression/SExpression.hpp
@@ -1,0 +1,33 @@
+//
+// Created by Matthew McCall on 4/9/24.
+//
+
+#ifndef SEXPRESSION_HPP
+#define SEXPRESSION_HPP
+
+#include <string>
+#include <list>
+
+/**
+ * Text to Tree
+ */
+namespace Oasis::t3 {
+
+struct Sexp {
+    Sexp() = default;
+
+    /**
+     * Represents and s-expression tree
+     * @param str The string to parse
+     */
+    explicit Sexp(const std::string& str);
+    
+    std::string label;
+    std::list<Sexp> operands; // so that add ops don't invalidate refs
+
+    bool BAD_SEXP = false;
+};
+
+}
+
+#endif //SEXPRESSION_HPP

--- a/src/Real.cpp
+++ b/src/Real.cpp
@@ -28,6 +28,13 @@ auto Real::ToString() const -> std::string
     return std::to_string(value);
 }
 
+auto Real::ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement*
+{
+    tinyxml2::XMLElement* const element = doc.NewElement("mn");
+    element->SetText(ToString().c_str());
+    return element;
+}
+
 auto Real::Specialize(const Expression& other) -> std::unique_ptr<Real>
 {
     return other.Is<Real>() ? std::make_unique<Real>(dynamic_cast<const Real&>(other)) : nullptr;

--- a/src/Subtract.cpp
+++ b/src/Subtract.cpp
@@ -105,6 +105,32 @@ auto Subtract<Expression>::ToString() const -> std::string
     return fmt::format("({} - {})", mostSigOp->ToString(), leastSigOp->ToString());
 }
 
+tinyxml2::XMLElement* Subtract<Expression>::ToMathMLElement(tinyxml2::XMLDocument& doc) const
+{
+    // mrow
+    tinyxml2::XMLElement* const mrow = doc.NewElement("mrow");
+    mrow->InsertFirstChild(mostSigOp->ToMathMLElement(doc));
+
+    // mo
+    tinyxml2::XMLElement* const mo = doc.NewElement("mo");
+    mo->SetText("-");
+    mrow->InsertEndChild(mo);
+
+    // (
+    tinyxml2::XMLElement* const leftParen = doc.NewElement("mo");
+    leftParen->SetText("(");
+    mrow->InsertEndChild(leftParen);
+
+    mrow->InsertEndChild(leastSigOp->ToMathMLElement(doc));
+
+    // )
+    tinyxml2::XMLElement* const rightParen = doc.NewElement("mo");
+    rightParen->SetText(")");
+    mrow->InsertEndChild(rightParen);
+
+    return mrow;
+}
+
 auto Subtract<Expression>::Simplify(tf::Subflow& subflow) const -> std::unique_ptr<Expression>
 {
     std::unique_ptr<Expression> simplifiedMinuend, simplifiedSubtrahend;

--- a/src/Undefined.cpp
+++ b/src/Undefined.cpp
@@ -11,6 +11,14 @@ auto Undefined::ToString() const -> std::string
     return "Undefined";
 }
 
+auto Undefined::ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement*
+{
+    tinyxml2::XMLElement* const mtext = doc.NewElement("mtext");
+    mtext->SetText("Undefined");
+
+    return mtext;
+}
+
 auto Undefined::Specialize(const Expression& other) -> std::unique_ptr<Undefined>
 {
     return other.Is<Undefined>() ? std::make_unique<Undefined>() : nullptr;

--- a/src/Variable.cpp
+++ b/src/Variable.cpp
@@ -26,6 +26,13 @@ auto Variable::ToString() const -> std::string
     return name;
 }
 
+auto Variable::ToMathMLElement(tinyxml2::XMLDocument& doc) const -> tinyxml2::XMLElement*
+{
+    tinyxml2::XMLElement* const mi = doc.NewElement("mi");
+    mi->SetText(name.c_str());
+    return mi;
+}
+
 auto Variable::Specialize(const Expression& other) -> std::unique_ptr<Variable>
 {
     return other.Is<Variable>() ? std::make_unique<Variable>(dynamic_cast<const Variable&>(other)) : nullptr;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,10 +12,11 @@ set(Oasis_TESTS
     DivideTests.cpp
     ExponentTests.cpp
     LogTests.cpp
+    MathMLTests.cpp
     MultiplyTests.cpp
     PolynomialTests.cpp
-        SubtractTests.cpp
-        MathMLTests.cpp)
+    SExpressionTests.cpp
+    SubtractTests.cpp)
 
 # Adds an executable target called "OasisTests" to be built from sources files.
 add_executable(OasisTests ${Oasis_TESTS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ set(Oasis_TESTS
     DifferentiateTests.cpp
     DivideTests.cpp
     ExponentTests.cpp
-        InFixTests.cpp
+    InFixTests.cpp
     LogTests.cpp
     MathMLTests.cpp
     MultiplyTests.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ set(Oasis_TESTS
     MultiplyTests.cpp
     NegateTests.cpp
     PolynomialTests.cpp
-    SExpressionTests.cpp
+#    SExpressionTests.cpp
     SubtractTests.cpp)
 
 # Adds an executable target called "OasisTests" to be built from sources files.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ set(Oasis_TESTS
     MultiplyTests.cpp
     NegateTests.cpp
     PolynomialTests.cpp
-#    SExpressionTests.cpp
+    # SExpressionTests.cpp
     SubtractTests.cpp)
 
 # Adds an executable target called "OasisTests" to be built from sources files.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,8 @@ set(Oasis_TESTS
     LogTests.cpp
     MultiplyTests.cpp
     PolynomialTests.cpp
-    SubtractTests.cpp)
+        SubtractTests.cpp
+        MathMLTests.cpp)
 
 # Adds an executable target called "OasisTests" to be built from sources files.
 add_executable(OasisTests ${Oasis_TESTS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(Oasis_TESTS
     BinaryExpressionTests.cpp
     DivideTests.cpp
     ExponentTests.cpp
+        InFixTests.cpp
     LogTests.cpp
     MathMLTests.cpp
     MultiplyTests.cpp

--- a/tests/InFixTests.cpp
+++ b/tests/InFixTests.cpp
@@ -1,0 +1,68 @@
+//
+// Created by Matthew McCall on 4/21/24.
+//
+
+#include "Oasis/Variable.hpp"
+
+#include <Oasis/Add.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <Oasis/FromString.hpp>
+#include <Oasis/Log.hpp>
+#include <Oasis/Multiply.hpp>
+
+TEST_CASE("In-Fix Parsing Works for Simple Trees", "[Sexp]")
+{
+    Oasis::Add expected {
+        Oasis::Real { 1.0 },
+        Oasis::Real { 2.0 }
+    };
+
+    const auto parsed = Oasis::FromInFix("1 + 2");
+
+    REQUIRE(parsed->Equals(expected));
+}
+
+TEST_CASE("In-Fix Parsing Respects Order of Operations")
+{
+    const Oasis::Add expected {
+        Oasis::Real { 1.0 },
+        Oasis::Multiply {
+            Oasis::Real { 2.0 },
+            Oasis::Real { 3.0 } }
+    };
+
+    const auto parsed = Oasis::FromInFix("1 + 2 * 3");
+
+    REQUIRE(parsed->Equals(expected));
+}
+
+TEST_CASE("In-Fix Parsing Works with Functions")
+{
+    const Oasis::Add expected {
+        Oasis::Real { 1.0 },
+        Oasis::Log {
+            Oasis::Real { 2.0 },
+            Oasis::Real { 3.0 } }
+    };
+
+    const auto parsed = Oasis::FromInFix("1 + log ( 2 , 3 )");
+
+    REQUIRE(parsed->Equals(expected));
+}
+
+TEST_CASE("In-Fix Parsing Works with Variables")
+{
+    const Oasis::Add<> expected {
+        Oasis::Multiply {
+            Oasis::Real { 1.0 },
+            Oasis::Variable { "x" } },
+        Oasis::Multiply {
+            Oasis::Variable { "y" },
+            Oasis::Real { 3.0 } }
+    };
+
+    const auto parsed = Oasis::FromInFix("1x + y3");
+
+    REQUIRE(parsed->Equals(expected));
+}

--- a/tests/MathMLTests.cpp
+++ b/tests/MathMLTests.cpp
@@ -1,0 +1,38 @@
+//
+// Created by Matthew McCall on 3/26/24.
+//
+#include "catch2/catch_test_macros.hpp"
+
+#include <Oasis/Add.hpp>
+#include <Oasis/Divide.hpp>
+#include <Oasis/Multiply.hpp>
+#include <Oasis/Variable.hpp>
+
+TEST_CASE("ToMathML Works", "[MathML]")
+{
+    Oasis::Divide divide {
+        Oasis::Add {
+            Oasis::Variable { "x" },
+            Oasis::Variable { "y" } },
+        Oasis::Multiply {
+            Oasis::Variable { "z" },
+            Oasis::Variable { "w" } }
+    };
+
+    auto mathml = divide.ToMathML();
+    std::string expected = R"(<mfrac>
+    <mrow>
+        <mi>x</mi>
+        <mo>+</mo>
+        <mi>y</mi>
+    </mrow>
+    <mrow>
+        <mi>z</mi>
+        <mo>*</mo>
+        <mi>w</mi>
+    </mrow>
+</mfrac>
+)";
+
+    REQUIRE(mathml == expected);
+}

--- a/tests/SExpressionTests.cpp
+++ b/tests/SExpressionTests.cpp
@@ -1,0 +1,60 @@
+//
+// Created by Matthew McCall on 4/12/24.
+//
+
+#include "../src/Parsers/SExpression/SExpression.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("S-Expression Parsing Works for Simple Trees", "[Sexp]")
+{
+    Oasis::t3::Sexp simpleAdd { "(+ 1 2)" };
+
+    REQUIRE(simpleAdd.label == "+");
+
+    const auto op = simpleAdd.operands.cbegin();
+    REQUIRE(op->label == "1");
+
+    const auto op2 = std::next(op);
+    REQUIRE(op2->label == "2");
+
+    const auto end = std::next(op2);
+    REQUIRE(end == simpleAdd.operands.cend());
+}
+
+TEST_CASE("S-Expression Parsing Works", "[Sexp]")
+{
+    Oasis::t3::Sexp add { "(+ (- 1 (* 2 4)) 2)" };
+
+    REQUIRE(add.label == "+");
+
+    const auto addOp = add.operands.cbegin();
+
+    const Oasis::t3::Sexp& minus = *addOp;
+    REQUIRE(minus.label == "-");
+
+    const auto minusOp = minus.operands.cbegin();
+    REQUIRE(minusOp->label == "1");
+
+    const auto minusOp2 = std::next(minusOp);
+    const Oasis::t3::Sexp& multiply = *minusOp2;
+    REQUIRE(multiply.label == "*");
+
+    const auto multiplyOp = multiply.operands.cbegin();
+    REQUIRE(multiplyOp->label == "2");
+
+    const auto multiplyOp2 = std::next(multiplyOp);
+    REQUIRE(multiplyOp2->label == "4");
+
+    const auto multiplyEnd = std::next(multiplyOp2);
+    REQUIRE(multiplyEnd == multiply.operands.end());
+
+    const auto minusEnd = std::next(minusOp2);
+    REQUIRE(minusEnd == minus.operands.cend());
+
+    const auto addOp2 = std::next(addOp);
+    REQUIRE(addOp2->label == "2");
+
+    const auto addEnd = std::next(addOp2);
+    REQUIRE(addEnd == add.operands.cend());
+}


### PR DESCRIPTION
This PR adds support for parsing Expressions from "in-fix" notation, using Dijkstra's shunting yard algorithm. This also adds support for serializing to MathML using tinyXML