### PR TITLE
Fix Calculus Tests

### DIFF
--- a/tests/DifferentiateTests.cpp
+++ b/tests/DifferentiateTests.cpp
@@ -12,7 +12,7 @@
 #include "Oasis/Variable.hpp"
 #include "Oasis/Derivative.hpp"
 
-TEST_CASE("Nonzero number", "[Differentiate][Real][Nonzero]")
+TEST_CASE("Differentiate Nonzero number", "[Differentiate][Real][Nonzero]")
 {
     Oasis::Real zero { 0.0f };
 
@@ -23,7 +23,7 @@ TEST_CASE("Nonzero number", "[Differentiate][Real][Nonzero]")
     REQUIRE(zero.Equals(*diff2));
 }
 
-TEST_CASE("Zero", "[Differentiate][Real][Zero]")
+TEST_CASE("Differentiate Zero", "[Differentiate][Real][Zero]")
 {
     Oasis::Variable constant { "C" };
     Oasis::Real zero { 0.0f };
@@ -33,7 +33,7 @@ TEST_CASE("Zero", "[Differentiate][Real][Zero]")
     REQUIRE(zero.Equals(*diff));
 }
 
-TEST_CASE("Same Variable", "[Differentiate][Variable][Same]")
+TEST_CASE("Differentiate Same Variable", "[Differentiate][Variable][Same]")
 {
     Oasis::Variable var { "x" };
     Oasis::Real result {1.0};
@@ -42,7 +42,7 @@ TEST_CASE("Same Variable", "[Differentiate][Variable][Same]")
     REQUIRE(result.Equals(*integrated));
 }
 
-TEST_CASE("Different Variable", "[Differentiate][Variable][Different]")
+TEST_CASE("Differentiate Different Variable", "[Differentiate][Variable][Different]")
 {
     Oasis::Variable var { "x" };
     Oasis::Variable var2 { "y" };
@@ -52,7 +52,7 @@ TEST_CASE("Different Variable", "[Differentiate][Variable][Different]")
     REQUIRE(zero.Equals(*diff));
 }
 
-TEST_CASE("Power Rule", "[Differentiate][Exponent][Power]")
+TEST_CASE("Differentiate Power Rule", "[Differentiate][Exponent][Power]")
 {
     Oasis::Variable var { "x" };
     Oasis::Exponent<Oasis::Variable, Oasis::Real> differentiate { Oasis::Variable { var.GetName() }, Oasis::Real { 3.0f } };
@@ -65,7 +65,7 @@ TEST_CASE("Power Rule", "[Differentiate][Exponent][Power]")
     REQUIRE((*diffed).Equals(*ptr));
 }
 
-TEST_CASE("Constant Rule Multiply", "[Differentiate][Multiply][Constant]")
+TEST_CASE("Differentiate Constant Rule Multiply", "[Differentiate][Multiply][Constant]")
 {
     Oasis::Variable var { "x" };
     Oasis::Multiply<Oasis::Real, Oasis::Variable> diff1 { Oasis::Real { 3.0f }, Oasis::Variable { var.GetName() } };
@@ -76,7 +76,7 @@ TEST_CASE("Constant Rule Multiply", "[Differentiate][Multiply][Constant]")
     REQUIRE((diffed->Equals(*ptr)));
 }
 
-TEST_CASE("Constant Rule Divide", "[Differentiate][Divide][Constant]")
+TEST_CASE("Differentiate Constant Rule Divide", "[Differentiate][Divide][Constant]")
 {
     Oasis::Variable var { "x" };
     Oasis::Divide<Oasis::Variable, Oasis::Real> diff1 { Oasis::Variable { var.GetName() }, Oasis::Real { 2.0f } };
@@ -86,7 +86,7 @@ TEST_CASE("Constant Rule Divide", "[Differentiate][Divide][Constant]")
     REQUIRE((simplified->Equals(*(half.Simplify()))));
 }
 
-TEST_CASE("Add Rule Different Terms", "[Differentiate][Add][Different]")
+TEST_CASE("Differentiate Add Rule Different Terms", "[Differentiate][Add][Different]")
 {
     Oasis::Variable var { "x" };
     Oasis::Add<Oasis::Variable, Oasis::Real>diff1 { Oasis::Variable { var.GetName() }, Oasis::Real { 2.0f } };
@@ -98,7 +98,7 @@ TEST_CASE("Add Rule Different Terms", "[Differentiate][Add][Different]")
     REQUIRE(simplified->Equals(*(one.Simplify())));
 }
 
-TEST_CASE("Subtract Rule Different Terms", "[Differentiate][Subtract][Different]")
+TEST_CASE("Differentiate Subtract Rule Different Terms", "[Differentiate][Subtract][Different]")
 {
     Oasis::Variable var { "x" };
     Oasis::Subtract<Oasis::Variable, Oasis::Real> diff1 { Oasis::Variable { var.GetName() }, Oasis::Real { 2.0f } };
@@ -109,7 +109,7 @@ TEST_CASE("Subtract Rule Different Terms", "[Differentiate][Subtract][Different]
     REQUIRE(simplified->Equals(*(one.Simplify())));
 }
 
-TEST_CASE("Add Rule Like Terms", "[Differentiate][Add][Like]")
+TEST_CASE("Differentiate Add Rule Like Terms", "[Differentiate][Add][Like]")
 {
     Oasis::Variable var { "x" };
     Oasis::Add<Oasis::Variable, Oasis::Variable> diff1 { Oasis::Variable { var.GetName() }, Oasis::Variable { var.GetName() } };
@@ -122,7 +122,7 @@ TEST_CASE("Add Rule Like Terms", "[Differentiate][Add][Like]")
     REQUIRE(simplified->Equals(*(two.Simplify())));
 }
 
-TEST_CASE("Quotient Rule Like Terms", "[Differentiate][Divide][Like]")
+TEST_CASE("Differentiate Quotient Rule Like Terms", "[Differentiate][Divide][Like]")
 {
     Oasis::Variable var{"x"}; // dx
     // derivative of [(x + 2)/(x + 3)]
@@ -152,7 +152,7 @@ TEST_CASE("Quotient Rule Like Terms", "[Differentiate][Divide][Like]")
     REQUIRE(simplified->Equals(*(simplifiedAns)));
 }
 
-TEST_CASE("Multiple Variables Differentiate", "[Differentiate][Multiply][Different]")
+TEST_CASE("Differentiate Multiple Variables Differentiate", "[Differentiate][Multiply][Different]")
 {
     Oasis::Variable x {"x"};
     Oasis::Variable y {"y"};
@@ -163,7 +163,7 @@ TEST_CASE("Multiple Variables Differentiate", "[Differentiate][Multiply][Differe
     REQUIRE(simplified->Equals(*(y.Simplify())));
 }
 
-TEST_CASE("Multiple Variables + Real Differentiate", "[Differentiate][Multiply][Different]")
+TEST_CASE("Differentiate Multiple Variables + Real Differentiate", "[Differentiate][Multiply][Different]")
 {
     Oasis::Variable x {"x"};
     Oasis::Variable y {"y"};

--- a/tests/IntegrateTests.cpp
+++ b/tests/IntegrateTests.cpp
@@ -8,7 +8,7 @@
 #include "Oasis/Subtract.hpp"
 #include "Oasis/Variable.hpp"
 
-TEST_CASE("Nonzero number", "[Integrate][Real][Nonzero]")
+TEST_CASE("Integrate Nonzero number", "[Integrate][Real][Nonzero]")
 {
     Oasis::Add<Oasis::Multiply<Oasis::Real, Oasis::Variable>, Oasis::Variable> integral {
         Oasis::Multiply {
@@ -24,7 +24,7 @@ TEST_CASE("Nonzero number", "[Integrate][Real][Nonzero]")
     REQUIRE(integral.Equals(*integrated));
 }
 
-TEST_CASE("Zero", "[Integrate][Real][Zero]")
+TEST_CASE("Integrate Zero", "[Integrate][Real][Zero]")
 {
     Oasis::Variable constant { "C" };
     Oasis::Real zero { 0.0f };
@@ -34,7 +34,7 @@ TEST_CASE("Zero", "[Integrate][Real][Zero]")
     REQUIRE(constant.Equals(*integrated));
 }
 
-TEST_CASE("Same Variable", "[Integrate][Variable][Same]")
+TEST_CASE("Integrate Same Variable", "[Integrate][Variable][Same]")
 {
     Oasis::Variable var { "x" };
     Oasis::Add<Oasis::Divide<Oasis::Exponent<Oasis::Variable, Oasis::Real>, Oasis::Real>, Oasis::Variable> integral {
@@ -49,7 +49,7 @@ TEST_CASE("Same Variable", "[Integrate][Variable][Same]")
     REQUIRE(ptr->Equals(*integrated));
 }
 
-TEST_CASE("Different Variable", "[Integrate][Variable][Different]")
+TEST_CASE("Integrate Different Variable", "[Integrate][Variable][Different]")
 {
     Oasis::Variable var { "x" };
     Oasis::Variable var2 { "y" };
@@ -64,7 +64,7 @@ TEST_CASE("Different Variable", "[Integrate][Variable][Different]")
     REQUIRE(integral.Equals(*integrated));
 }
 
-TEST_CASE("Power Rule", "[Integrate][Exponent][Power]")
+TEST_CASE("Integrate Power Rule", "[Integrate][Exponent][Power]")
 {
     Oasis::Variable var { "x" };
     Oasis::Exponent<Oasis::Variable, Oasis::Real> integrand { Oasis::Variable { var.GetName() }, Oasis::Real { 2.0f } };
@@ -79,7 +79,7 @@ TEST_CASE("Power Rule", "[Integrate][Exponent][Power]")
     REQUIRE((*integrated).Equals(*ptr));
 }
 
-TEST_CASE("Constant Rule Multiply", "[Integrate][Multiply][Constant]")
+TEST_CASE("Integrate Constant Rule Multiply", "[Integrate][Multiply][Constant]")
 {
     Oasis::Variable var { "x" };
     Oasis::Multiply<Oasis::Real, Oasis::Variable> integrand { Oasis::Real { 3.0f }, Oasis::Variable { var.GetName() } };
@@ -100,7 +100,7 @@ TEST_CASE("Constant Rule Multiply", "[Integrate][Multiply][Constant]")
     REQUIRE((integrated->Equals(*ptr)));
 }
 
-TEST_CASE("Constant Rule Divide", "[Integrate][Divide][Constant]")
+TEST_CASE("Integrate Constant Rule Divide", "[Integrate][Divide][Constant]")
 {
     Oasis::Variable var { "x" };
     Oasis::Divide<Oasis::Variable, Oasis::Real> integrand { Oasis::Variable { var.GetName() }, Oasis::Real { 3.0f } };
@@ -120,7 +120,7 @@ TEST_CASE("Constant Rule Divide", "[Integrate][Divide][Constant]")
     REQUIRE((simplified->Equals(*(integral.Simplify()))));
 }
 
-TEST_CASE("Add Rule Different Terms", "[Integrate][Add][Different]")
+TEST_CASE("Integrate Add Rule Different Terms", "[Integrate][Add][Different]")
 {
     Oasis::Variable var { "x" };
     Oasis::Add<Oasis::Variable, Oasis::Real> integrand { Oasis::Variable { var.GetName() }, Oasis::Real { 2.0f } };
@@ -142,7 +142,7 @@ TEST_CASE("Add Rule Different Terms", "[Integrate][Add][Different]")
     REQUIRE(simplified->Equals(*(integral.Simplify())));
 }
 
-TEST_CASE("Subtract Rule Different Terms", "[Integrate][Subtract][Different]")
+TEST_CASE("Integrate Subtract Rule Different Terms", "[Integrate][Subtract][Different]")
 {
     Oasis::Variable var { "x" };
     Oasis::Subtract<Oasis::Variable, Oasis::Real> integrand { Oasis::Variable { var.GetName() }, Oasis::Real { 2.0f } };
@@ -163,7 +163,7 @@ TEST_CASE("Subtract Rule Different Terms", "[Integrate][Subtract][Different]")
     REQUIRE(integrated->Equals(*(integral.Simplify())));
 }
 
-TEST_CASE("Add Rule Like Terms", "[Integrate][Add][Like]")
+TEST_CASE("Integrate Add Rule Like Terms", "[Integrate][Add][Like]")
 {
     Oasis::Variable var { "x" };
     Oasis::Add<Oasis::Variable, Oasis::Variable> integrand { Oasis::Variable { var.GetName() }, Oasis::Variable { var.GetName() } };


### PR DESCRIPTION
Some derivative and integral tests had the same names which caused one or the other to be skipped. This has been rectified by giving each test a unique name,