### PR TITLE
Replaced exceptions with ParseResult

### DIFF
--- a/extras/include/Oasis/FromString.hpp
+++ b/extras/include/Oasis/FromString.hpp
@@ -6,7 +6,20 @@
 #define FROMSTRING_HPP
 
 namespace Oasis {
-auto FromInFix(const std::string& str) -> std::unique_ptr<Expression>;
+
+class ParseResult {
+public:
+    explicit ParseResult(std::unique_ptr<Expression> expr);
+    explicit ParseResult(std::string err);
+
+    [[nodiscard]] bool Ok() const;
+    [[nodiscard]] const Expression& GetResult() const;
+
+private:
+    std::variant<std::unique_ptr<Expression>, std::string> result;
+};
+
+auto FromInFix(const std::string& str) -> ParseResult;
 
 }
 

--- a/extras/src/FromString.cpp
+++ b/extras/src/FromString.cpp
@@ -19,6 +19,7 @@
 #include "Oasis/FromString.hpp"
 
 #include "../../include/Oasis/Derivative.hpp"
+#include "fmt/format.h"
 
 namespace {
 
@@ -44,7 +45,7 @@ void setOps(T& exp, const std::unique_ptr<Oasis::Expression>& op1, const std::un
     }
 }
 
-void processOp(std::stack<std::string>& ops, std::stack<std::unique_ptr<Oasis::Expression>>& st)
+bool processOp(std::stack<std::string>& ops, std::stack<std::unique_ptr<Oasis::Expression>>& st)
 {
     const auto right = std::move(st.top());
     st.pop();
@@ -84,15 +85,15 @@ void processOp(std::stack<std::string>& ops, std::stack<std::unique_ptr<Oasis::E
         break;
     }
     default:
-        throw std::runtime_error("Unknown operator encountered: " + op);
+        return false;
     }
 
     st.emplace(std::move(opExp));
-    // }
     ops.pop();
+    return true;
 }
 
-void processFunction(std::stack<std::unique_ptr<Oasis::Expression>>& st, const std::string& function_token)
+bool processFunction(std::stack<std::unique_ptr<Oasis::Expression>>& st, const std::string& function_token)
 {
     // If we have a function active, the second operand has just been pushed onto the stack
     auto second_operand = std::move(st.top());
@@ -114,10 +115,11 @@ void processFunction(std::stack<std::unique_ptr<Oasis::Expression>>& st, const s
         Oasis::Integral<> in;
         setOps(in, first_operand, second_operand);
     } else {
-        throw std::runtime_error("Unknown function encountered: " + function_token);
+        return false;
     }
 
     st.emplace(std::move(func));
+    return true;
 }
 
 std::vector<std::string> tokenizeMultiplicands(const std::string& expression)
@@ -195,11 +197,24 @@ std::unique_ptr<Oasis::Expression> multiplyFromVariables(const std::vector<std::
 }
 
 namespace Oasis {
-class Expression;
 
-auto FromInFix(const std::string& str) -> std::unique_ptr<Expression>
-{
-    // Based of Dijkstra's Shunting Yard
+ParseResult::ParseResult(std::unique_ptr<Expression> expr) {
+    result = std::move(expr);
+}
+
+ParseResult::ParseResult(std::string err) : result(err) {
+}
+
+bool ParseResult::Ok() const {
+    return result.index() == 0;
+}
+
+auto ParseResult::GetResult() const -> const Expression & {
+    return *std::get<std::unique_ptr<Expression>>(result);
+}
+
+auto FromInFix(const std::string& str) -> ParseResult {
+    // Based off Dijkstra's Shunting Yard
 
     std::stack<std::unique_ptr<Expression>> st;
     std::stack<std::string> ops;
@@ -220,25 +235,33 @@ auto FromInFix(const std::string& str) -> std::unique_ptr<Expression>
         else if (token == ",") {
             // function_active = true;
             while (!ops.empty() && ops.top() != "(") {
-                processOp(ops, st);
+                if (!processOp(ops, st)) {
+                    return ParseResult { fmt::format(R"(Unknown operator: "{}")", token) };
+                }
             }
         }
         // ')'
         else if (token == ")") {
             while (!ops.empty() && ops.top() != "(") {
-                processOp(ops, st);
+                if (!processOp(ops, st)) {
+                    return ParseResult { fmt::format(R"(Unknown operator: "{}")", token) };
+                }
             }
             ops.pop(); // pop '('
             if (!ops.empty() && is_function(ops.top())) {
                 std::string func = ops.top();
                 ops.pop();
-                processFunction(st, func);
+                if (!processFunction(st, func)) {
+                    return ParseResult { fmt::format(R"(Unknown function: "{}")", token) };
+                }
             }
         }
         // Operator
         else if (is_operator(token)) {
             while (!ops.empty() && prec(ops.top()[0]) >= prec(token[0])) {
-                processOp(ops, st);
+                if (!processOp(ops, st)) {
+                    return ParseResult { fmt::format(R"(Unknown operator: "{}")", token) };
+                }
             }
             ops.push(token);
         } else if (ss.peek() != '(') {
@@ -248,10 +271,12 @@ auto FromInFix(const std::string& str) -> std::unique_ptr<Expression>
 
     // Process remaining ops
     while (!ops.empty()) {
-        processOp(ops, st);
+        if (!processOp(ops, st)) {
+            return ParseResult { fmt::format(R"(Unknown operator: "{}")", token) };
+        }
     }
 
-    return st.top()->Copy(); // root of the expression tree
+    return ParseResult { st.top()->Copy() }; // root of the expression tree
 }
 
 }

--- a/extras/src/FromString.cpp
+++ b/extras/src/FromString.cpp
@@ -18,7 +18,6 @@
 
 #include "Oasis/FromString.hpp"
 
-#include "../../include/Oasis/Derivative.hpp"
 #include "fmt/format.h"
 
 namespace {

--- a/extras/tests/InFixTests.cpp
+++ b/extras/tests/InFixTests.cpp
@@ -17,9 +17,11 @@ TEST_CASE("In-Fix Parsing Works for Simple Trees", "[Sexp]")
         Oasis::Real { 2.0 }
     };
 
-    const auto parsed = Oasis::FromInFix("1 + 2");
+    const auto result = Oasis::FromInFix("1 + 2");
+    REQUIRE(result.Ok());
 
-    REQUIRE(parsed->Equals(expected));
+    const auto& parsed = result.GetResult();
+    REQUIRE(parsed.Equals(expected));
 }
 
 TEST_CASE("In-Fix Parsing Respects Order of Operations")
@@ -31,9 +33,11 @@ TEST_CASE("In-Fix Parsing Respects Order of Operations")
             Oasis::Real { 3.0 } }
     };
 
-    const auto parsed = Oasis::FromInFix("1 + 2 * 3");
+    const auto result = Oasis::FromInFix("1 + 2 * 3");
+    REQUIRE(result.Ok());
 
-    REQUIRE(parsed->Equals(expected));
+    const auto& parsed = result.GetResult();
+    REQUIRE(parsed.Equals(expected));
 }
 
 TEST_CASE("In-Fix Parsing Works with Functions")
@@ -45,9 +49,11 @@ TEST_CASE("In-Fix Parsing Works with Functions")
             Oasis::Real { 3.0 } }
     };
 
-    const auto parsed = Oasis::FromInFix("1 + log ( 2 , 3 )");
+    const auto result = Oasis::FromInFix("1 + log ( 2 , 3 )");
+    REQUIRE(result.Ok());
 
-    REQUIRE(parsed->Equals(expected));
+    const auto& parsed = result.GetResult();
+    REQUIRE(parsed.Equals(expected));
 }
 
 TEST_CASE("In-Fix Parsing Works with Variables")
@@ -61,7 +67,10 @@ TEST_CASE("In-Fix Parsing Works with Variables")
             Oasis::Real { 3.0 } }
     };
 
-    const auto parsed = Oasis::FromInFix("1x + y3");
+    const auto result = Oasis::FromInFix("1x + y3");
+    REQUIRE(result.Ok());
 
-    REQUIRE(parsed->Equals(expected));
+
+    const auto& parsed = result.GetResult();
+    REQUIRE(parsed.Equals(expected));
 }


### PR DESCRIPTION
This removes the old means of trying to parse an expression and catching an exception when it fails with the more tried and true methodology of returning errors as values.